### PR TITLE
Switch working trigger from PreToolUse to UserPromptSubmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Add to your `~/.claude/settings.json`:
 ```json
 {
   "hooks": {
-    "PreToolUse": [
+    "UserPromptSubmit": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/tmux/plugins/tmux-claude-status/hooks/better-hook.sh PreToolUse"
+            "command": "~/.config/tmux/plugins/tmux-claude-status/hooks/better-hook.sh UserPromptSubmit"
           }
         ]
       }
@@ -123,7 +123,7 @@ Wait mode allows you to temporarily defer a session and automatically switch to 
 ## How It Works
 
 The plugin uses [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) to track status:
-- `PreToolUse` - Sets status to "working" when Claude starts running tools
+- `UserPromptSubmit` - Sets status to "working" when the user submits a prompt
 - `Stop` - Sets status to "done" when Claude finishes processing
 - `Notification` - Sets status to "done" when Claude is waiting for user input (questions, permissions, etc.)
 

--- a/hooks/better-hook.sh
+++ b/hooks/better-hook.sh
@@ -43,8 +43,8 @@ if [ -n "$TMUX" ] || [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
         WAIT_FILE="$STATUS_DIR/wait/${TMUX_SESSION}.wait"
         
         case "$HOOK_TYPE" in
-            "PreToolUse")
-                # Claude is starting to work - cancel wait mode if active
+            "UserPromptSubmit")
+                # User submitted a prompt - Claude is starting to work, cancel wait mode if active
                 if [ -f "$WAIT_FILE" ]; then
                     rm -f "$WAIT_FILE"  # Remove wait timer
                 fi

--- a/setup-server.sh
+++ b/setup-server.sh
@@ -52,12 +52,12 @@ scp "$SCRIPT_DIR/hooks/better-hook.sh" "$SSH_HOST:~/.config/tmux/plugins/tmux-cl
 echo "Setting up Claude hooks on remote..."
 CLAUDE_SETTINGS='{
   "hooks": {
-    "PreToolUse": [
+    "UserPromptSubmit": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/tmux/plugins/tmux-claude-status/hooks/better-hook.sh PreToolUse"
+            "command": "~/.config/tmux/plugins/tmux-claude-status/hooks/better-hook.sh UserPromptSubmit"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Replace `PreToolUse` hook with `UserPromptSubmit` across hook script, README, and SSH setup script
- Eliminates the "thinking gap" where Claude is processing but status still shows "done"
- Catches pure text replies that never trigger any tools

## Test plan

- [x] Submit a prompt — status should immediately show "working" before any tool is called
- [x] Verify pure text replies (no tool use) still trigger "working" status
- [x] Confirm SSH setup script deploys correct hook config

🤖 Generated with [Claude Code](https://claude.com/claude-code)