### PR TITLE
Add UserPromptSubmit hook and fix SubagentStop premature done

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ Add to your `~/.claude/settings.json`:
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/tmux/plugins/tmux-claude-status/hooks/better-hook.sh PreToolUse"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
@@ -124,6 +134,7 @@ Wait mode allows you to temporarily defer a session and automatically switch to 
 
 The plugin uses [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) to track status:
 - `UserPromptSubmit` - Sets status to "working" when the user submits a prompt
+- `PreToolUse` - Re-affirms "working" status when Claude calls a tool (backup trigger)
 - `Stop` - Sets status to "done" when Claude finishes processing
 - `Notification` - Sets status to "done" when Claude is waiting for user input (questions, permissions, etc.)
 

--- a/hooks/better-hook.sh
+++ b/hooks/better-hook.sh
@@ -43,8 +43,8 @@ if [ -n "$TMUX" ] || [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
         WAIT_FILE="$STATUS_DIR/wait/${TMUX_SESSION}.wait"
         
         case "$HOOK_TYPE" in
-            "UserPromptSubmit")
-                # User submitted a prompt - Claude is starting to work, cancel wait mode if active
+            "UserPromptSubmit"|"PreToolUse")
+                # User submitted a prompt or Claude is calling a tool - cancel wait mode if active
                 if [ -f "$WAIT_FILE" ]; then
                     rm -f "$WAIT_FILE"  # Remove wait timer
                 fi
@@ -54,8 +54,8 @@ if [ -n "$TMUX" ] || [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
                     echo "working" > "$REMOTE_STATUS_FILE" 2>/dev/null
                 fi
                 ;;
-            "Stop"|"SubagentStop")
-                # Claude has finished responding
+            "Stop")
+                # Claude has finished responding (SubagentStop excluded - subagents finishing doesn't mean the main agent is done)
                 echo "done" > "$STATUS_FILE"
                 # Only write to remote status file if we're in an SSH session
                 if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then

--- a/setup-server.sh
+++ b/setup-server.sh
@@ -62,6 +62,16 @@ CLAUDE_SETTINGS='{
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/tmux/plugins/tmux-claude-status/hooks/better-hook.sh PreToolUse"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

- Add `UserPromptSubmit` as primary "working" trigger — fires the moment the user hits Enter, eliminating the thinking gap where status showed "done"
- Keep `PreToolUse` as a backup trigger to re-affirm "working" on each tool call
- Remove `SubagentStop` from the Stop handler — subagent completions were prematurely resetting status to "done" during long tasks

Supersedes #6.

## Test plan

- [ ] Submit a prompt — status should immediately show "working" before any tool is called
- [ ] During long tasks with subagents, status should stay "working" until the main agent finishes
- [ ] Pure text replies (no tool use) should still trigger "working" status
- [ ] Verify SSH setup script deploys correct hook config

🤖 Generated with [Claude Code](https://claude.com/claude-code)