### PR TITLE
Fix iTerm2 Control Mode compatibility

### DIFF
--- a/tmux-claude-status.tmux
+++ b/tmux-claude-status.tmux
@@ -25,6 +25,13 @@ tmux bind-key "$next_done_key" run-shell "$CURRENT_DIR/scripts/next-done-project
 # Set up keybinding to put session in wait mode
 tmux bind-key "$wait_key" run-shell "$CURRENT_DIR/scripts/wait-session.sh"
 
+# Detect iTerm2 Control Mode (tmux -CC) and skip status polling / daemons
+# to avoid interfering with the control protocol. Keybindings above are fine.
+control_mode=$(tmux display-message -p '#{client_control_mode}' 2>/dev/null)
+if [ "$control_mode" = "1" ]; then
+    exit 0
+fi
+
 # Set up tmux status line integration
 tmux set-option -g status-interval 1
 


### PR DESCRIPTION
## Summary
- Detect `tmux -CC` (Control Mode) at plugin init time via `#{client_control_mode}`
- Skip status-line polling and background daemons that interfere with the control protocol
- Keybindings are still registered and work normally

Fixes #1

## Test plan
- [ ] Normal tmux: plugin works as before (status bar, daemons, sounds)
- [ ] `tmux -CC`: no "Slow tmux Response" hang, iTerm2 connects successfully
- [ ] CI keybinding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)