### PR TITLE
Fix notification sound not playing from hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ set -g @claude-wait-key "w"
 A notification sound plays when Claude finishes. Configure with:
 
 ```tmux
-set -g @claude-notification-sound "bell"
+set -g @claude-notification-sound "chime"
 ```
 
 | Value | Description |
 |-------|-------------|
-| `bell` | Classic bell (default) |
-| `chime` | Subtle chime |
+| `chime` | Subtle chime (default) |
+| `bell` | Classic bell |
 | `fanfare` | Triumphant fanfare |
 | `frog` | Comical frog ribbit |
 | `speech` | TTS voice: "Claude ready" |

--- a/hooks/better-hook.sh
+++ b/hooks/better-hook.sh
@@ -72,7 +72,7 @@ if [ -n "$TMUX" ] || [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
 
                 # Play notification sound when Claude finishes
                 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-                "$SCRIPT_DIR/../scripts/play-sound.sh" &
+                "$SCRIPT_DIR/../scripts/play-sound.sh" 2>/dev/null &
                 ;;
         esac
     fi

--- a/scripts/play-sound.sh
+++ b/scripts/play-sound.sh
@@ -7,6 +7,11 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Ensure PulseAudio/PipeWire environment is available (hooks may lack user env)
+: "${XDG_RUNTIME_DIR:=/run/user/$(id -u)}"
+: "${DISPLAY:=:0}"
+export XDG_RUNTIME_DIR DISPLAY
+
 SOUND_CHOICE=$(tmux show-option -gqv @claude-notification-sound 2>/dev/null)
 : "${SOUND_CHOICE:=chime}"
 
@@ -47,20 +52,21 @@ case "$SOUND_CHOICE" in
         ;;
 esac
 
+# Run sound players in foreground - callers background this script with &
 if [ -n "${BUNDLED_SOUND:-}" ] && [ -f "$BUNDLED_SOUND" ]; then
     if command -v paplay >/dev/null 2>&1; then
-        paplay "$BUNDLED_SOUND" 2>/dev/null &
+        paplay "$BUNDLED_SOUND" 2>/dev/null
     elif command -v afplay >/dev/null 2>&1; then
-        afplay "$BUNDLED_SOUND" 2>/dev/null &
+        afplay "$BUNDLED_SOUND" 2>/dev/null
     elif command -v aplay >/dev/null 2>&1; then
-        aplay "$BUNDLED_SOUND" 2>/dev/null &
+        aplay "$BUNDLED_SOUND" 2>/dev/null
     fi
 elif command -v paplay >/dev/null 2>&1 && [ -f "$LINUX_SOUND" ]; then
-    paplay "$LINUX_SOUND" 2>/dev/null &
+    paplay "$LINUX_SOUND" 2>/dev/null
 elif command -v afplay >/dev/null 2>&1; then
-    afplay "/System/Library/Sounds/$MAC_SOUND" 2>/dev/null &
+    afplay "/System/Library/Sounds/$MAC_SOUND" 2>/dev/null
 elif command -v beep >/dev/null 2>&1; then
-    beep 2>/dev/null &
+    beep 2>/dev/null
 else
     echo -ne '\a'
 fi


### PR DESCRIPTION
## Summary
- Set `XDG_RUNTIME_DIR` and `DISPLAY` defaults in `play-sound.sh` so `paplay` works in the restricted environment Claude Code hooks run in
- Run sound players in foreground (callers already background the script) to prevent premature process termination
- Update README to reflect chime as default sound

## Test plan
- [ ] Verify chime plays when Claude finishes (Notification hook)
- [ ] Verify sound works on fresh tmux session without explicit `@claude-notification-sound` set
- [ ] Verify macOS `afplay` path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)