### PR TITLE
Add multi-session deploy to git worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ set -g @claude-notification-sound "chime"
 
 Changes take effect immediately — no tmux reload needed.
 
+## Multi-Session Deploy
+
+Spin up parallel Claude Code sessions from within a running session. Each gets its own tmux session and git worktree for file isolation.
+
+Use the `/deploy` skill from Claude Code, or call the script directly:
+
+```bash
+cat > /tmp/manifest.json << 'EOF'
+{
+  "sessions": [
+    { "name": "refactor-auth", "prompt": "Refactor auth to use JWT..." },
+    { "prompt": "Write tests for the API endpoints..." }
+  ],
+  "working_directory": "/path/to/repo"
+}
+EOF
+
+bash ~/.config/tmux/plugins/tmux-claude-status/scripts/deploy-sessions.sh /tmp/manifest.json
+```
+
+Each session gets a `deploy/<name>` branch and worktree at `.claude/worktrees/<name>/`. Set `"worktrees": false` in the manifest if sessions need to collaborate on the same files. Status monitoring picks up new sessions automatically.
+
 ## SSH Sessions
 
 Track Claude status on remote servers:

--- a/scripts/claude-launcher.sh
+++ b/scripts/claude-launcher.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Launcher for deployed Claude Code sessions
+# Reads prompt from a temp file and execs claude
+
+prompt_file="$1"
+
+if [ -n "$prompt_file" ] && [ -f "$prompt_file" ]; then
+    prompt=$(cat "$prompt_file")
+    rm -f "$prompt_file"
+    exec claude --dangerously-skip-permissions "$prompt"
+else
+    # No prompt file — fall back to interactive
+    exec claude --dangerously-skip-permissions
+fi

--- a/scripts/deploy-sessions.sh
+++ b/scripts/deploy-sessions.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+# Deploy multiple Claude Code sessions from a JSON manifest
+# Each session gets its own git worktree (if in a repo) and tmux session
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAUNCHER="$SCRIPT_DIR/claude-launcher.sh"
+
+# --- Validation ---
+
+manifest="$1"
+
+if [ -z "$manifest" ]; then
+    echo '{"error": "Usage: deploy-sessions.sh <manifest.json>"}' >&2
+    exit 1
+fi
+
+if [ ! -f "$manifest" ]; then
+    echo "{\"error\": \"Manifest not found: $manifest\"}" >&2
+    exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+    echo '{"error": "jq is required but not installed"}' >&2
+    exit 1
+fi
+
+if ! jq empty "$manifest" 2>/dev/null; then
+    echo '{"error": "Invalid JSON in manifest"}' >&2
+    exit 1
+fi
+
+# --- Parse manifest ---
+
+working_dir=$(jq -r '.working_directory // empty' "$manifest")
+[ -z "$working_dir" ] && working_dir="$PWD"
+
+# Resolve to absolute path
+working_dir=$(cd "$working_dir" && pwd)
+
+# Detect git repo
+is_git_repo=false
+if git -C "$working_dir" rev-parse --git-dir &>/dev/null; then
+    is_git_repo=true
+    git_root=$(git -C "$working_dir" rev-parse --show-toplevel)
+fi
+
+# Worktrees: on by default, can be disabled with "worktrees": false
+use_worktrees=$(jq -r '.worktrees // true' "$manifest")
+
+session_count=$(jq '.sessions | length' "$manifest")
+if [ "$session_count" -eq 0 ]; then
+    echo '{"error": "No sessions in manifest"}' >&2
+    exit 1
+fi
+
+# --- Helpers ---
+
+sanitize_name() {
+    # Lowercase, replace non-alnum with hyphens, collapse, trim, truncate
+    echo "$1" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9-]/-/g' \
+        | sed 's/--*/-/g' \
+        | sed 's/^-//;s/-$//' \
+        | cut -c1-30
+}
+
+derive_name() {
+    # First ~4 words of prompt, sanitized
+    echo "$1" | tr '\n' ' ' | awk '{for(i=1;i<=4&&i<=NF;i++) printf "%s ", $i}' | sanitize_name
+}
+
+unique_name() {
+    local base="$1"
+    local name="$base"
+    local suffix=2
+
+    while tmux has-session -t "=$name" 2>/dev/null; do
+        name="${base}-${suffix}"
+        suffix=$((suffix + 1))
+    done
+    echo "$name"
+}
+
+unique_branch() {
+    local base="$1"
+    local branch="$base"
+    local suffix=2
+
+    while git -C "$git_root" show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null; do
+        branch="${base}-${suffix}"
+        suffix=$((suffix + 1))
+    done
+    echo "$branch"
+}
+
+# --- Deploy sessions ---
+
+if [ "$is_git_repo" = true ] && [ "$use_worktrees" = "true" ]; then
+    worktree_base="$git_root/.claude/worktrees"
+    mkdir -p "$worktree_base"
+fi
+
+deployed=0
+results="[]"
+errors="[]"
+
+for i in $(seq 0 $((session_count - 1))); do
+    prompt=$(jq -r ".sessions[$i].prompt" "$manifest")
+    raw_name=$(jq -r ".sessions[$i].name // empty" "$manifest")
+
+    if [ -z "$prompt" ] || [ "$prompt" = "null" ]; then
+        errors=$(echo "$errors" | jq --arg i "$i" '. + ["Session \($i): missing prompt"]')
+        continue
+    fi
+
+    # Resolve session name
+    if [ -n "$raw_name" ]; then
+        base_name=$(sanitize_name "$raw_name")
+    else
+        base_name=$(derive_name "$prompt")
+    fi
+    [ -z "$base_name" ] && base_name="session-$i"
+
+    session_name=$(unique_name "$base_name")
+
+    # Determine working directory for this session
+    session_dir="$working_dir"
+    branch_name=""
+
+    if [ "$is_git_repo" = true ] && [ "$use_worktrees" = "true" ]; then
+        branch_name=$(unique_branch "deploy/$session_name")
+        worktree_path="$worktree_base/$session_name"
+
+        # Handle worktree path collision
+        if [ -d "$worktree_path" ]; then
+            suffix=2
+            while [ -d "${worktree_path}-${suffix}" ]; do
+                suffix=$((suffix + 1))
+            done
+            worktree_path="${worktree_path}-${suffix}"
+        fi
+
+        if git -C "$git_root" worktree add "$worktree_path" -b "$branch_name" 2>/dev/null; then
+            session_dir="$worktree_path"
+        else
+            errors=$(echo "$errors" | jq --arg n "$session_name" '. + ["Failed to create worktree for \($n)"]')
+            # Fall back to working_dir
+        fi
+    fi
+
+    # Write prompt to temp file
+    prompt_file="/tmp/claude-deploy-prompt-${session_name}-$$.txt"
+    printf '%s' "$prompt" > "$prompt_file"
+
+    # Create tmux session and launch Claude
+    tmux new-session -d -s "$session_name" -c "$session_dir"
+    tmux send-keys -t "$session_name" "bash '$LAUNCHER' '$prompt_file'" Enter
+
+    deployed=$((deployed + 1))
+
+    # Build result entry
+    entry=$(jq -n \
+        --arg name "$session_name" \
+        --arg dir "$session_dir" \
+        --arg branch "$branch_name" \
+        '{name: $name, directory: $dir, branch: (if $branch == "" then null else $branch end)}')
+    results=$(echo "$results" | jq --argjson e "$entry" '. + [$e]')
+done
+
+# Clean up manifest
+rm -f "$manifest"
+
+# Output summary
+jq -n \
+    --argjson deployed "$deployed" \
+    --argjson sessions "$results" \
+    --argjson errors "$errors" \
+    '{deployed: $deployed, sessions: $sessions, errors: (if ($errors | length) > 0 then $errors else null end)}'


### PR DESCRIPTION
## Summary

- Adds `scripts/deploy-sessions.sh` — parses a JSON manifest and spins up N Claude Code sessions, each in its own tmux session and git worktree (branch `deploy/<name>`)
- Adds `scripts/claude-launcher.sh` — helper that reads a prompt from a temp file and execs Claude, avoiding all shell quoting issues
- Worktrees are on by default but can be disabled (`"worktrees": false`) for sessions that need to collaborate on the same files
- Session names auto-derived from prompts when not specified, with collision-safe suffixes
- Graceful fallback when not in a git repo (deploys without worktrees)
- Zero config needed — existing hook-based status monitoring picks up new sessions automatically

A companion `/deploy` skill (installed in `~/.claude/skills/deploy/`) teaches Claude the manifest format and deploy workflow.

## Test plan

- [ ] Deploy a 2-session manifest and verify tmux sessions + worktrees are created
- [ ] Verify Claude launches in each session with the correct prompt
- [ ] Test name collision handling (deploy with duplicate names)
- [ ] Test `"worktrees": false` — sessions share the same directory
- [ ] Test from a non-git directory — sessions deploy without worktrees
- [ ] Test with a multi-paragraph prompt containing special characters
- [ ] Verify manifest and prompt temp files are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)