### PR TITLE
Fix wait timer creating stale remote status for local sessions

### DIFF
--- a/scripts/status-line.sh
+++ b/scripts/status-line.sh
@@ -18,7 +18,8 @@ check_wait_timers() {
         local expiry_time=$(cat "$wait_file" 2>/dev/null)
         if [ -n "$expiry_time" ] && [ "$current_time" -ge "$expiry_time" ]; then
             echo "done" > "$STATUS_DIR/${session_name}.status" 2>/dev/null
-            echo "done" > "$STATUS_DIR/${session_name}-remote.status" 2>/dev/null
+            # Only update remote status if it already exists (SSH sessions)
+            [ -f "$STATUS_DIR/${session_name}-remote.status" ] && echo "done" > "$STATUS_DIR/${session_name}-remote.status" 2>/dev/null
             rm -f "$wait_file"
         fi
     done


### PR DESCRIPTION
## Summary
- `check_wait_timers()` from #15 unconditionally wrote "done" to `-remote.status`, creating the file even for local sessions
- `count_claude_status()` checks `-remote.status` first, so the stale "done" shadowed the correct "working" in the local status file
- Fix: only write to `-remote.status` if it already exists (i.e., it's an SSH session)

## Test plan
- [ ] Put a local session into wait, let it expire, then start working — status should flip to "working"
- [ ] SSH sessions with wait timers should still transition correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)