### PR TITLE
Fix stale wait state cleanup

### DIFF
--- a/scripts/hook-based-switcher.sh
+++ b/scripts/hook-based-switcher.sh
@@ -45,19 +45,36 @@ get_ssh_host() {
 }
 
 # Function to get agent status from hook files
+normalize_local_wait_status() {
+    local session="$1"
+    local status_file="$STATUS_DIR/${session}.status"
+    local wait_file="$STATUS_DIR/wait/${session}.wait"
+
+    [ ! -f "$status_file" ] && return
+
+    local status
+    status=$(cat "$status_file" 2>/dev/null || echo "")
+    if [ "$status" = "wait" ] && [ ! -f "$wait_file" ]; then
+        echo "done" > "$status_file" 2>/dev/null
+    fi
+}
+
 get_agent_status() {
     local session="$1"
 
     # Check for remote status file first (for SSH sessions)
     local remote_status="$STATUS_DIR/${session}-remote.status"
-    if [ -f "$remote_status" ]; then
+    if [ -f "$remote_status" ] && is_ssh_session "$session"; then
         cat "$remote_status" 2>/dev/null
         return
+    elif [ -f "$remote_status" ] && ! is_ssh_session "$session"; then
+        rm -f "$remote_status" 2>/dev/null
     fi
 
     # Check local status files
     local status_file="$STATUS_DIR/${session}.status"
     if [ -f "$status_file" ]; then
+        normalize_local_wait_status "$session"
         cat "$status_file" 2>/dev/null || echo ""
     else
         echo ""
@@ -191,8 +208,14 @@ perform_full_reset() {
     # Clear PID files
     find "$STATUS_DIR" -type f -name "*.pid" -delete 2>/dev/null
 
-    # Clear wait files
-    find "$STATUS_DIR/wait" -type f -name "*.wait" -delete 2>/dev/null
+    # Clear wait files and normalize matching wait statuses back to done
+    for wait_file in "$STATUS_DIR/wait"/*.wait; do
+        [ ! -f "$wait_file" ] && continue
+        session_name=$(basename "$wait_file" .wait)
+        [ -f "$STATUS_DIR/${session_name}.status" ] && echo "done" > "$STATUS_DIR/${session_name}.status" 2>/dev/null
+        [ -f "$STATUS_DIR/${session_name}-remote.status" ] && echo "done" > "$STATUS_DIR/${session_name}-remote.status" 2>/dev/null
+        rm -f "$wait_file" 2>/dev/null
+    done
 
     # Clear temp files
     rm -f "$STATUS_DIR"/.*.status.tmp 2>/dev/null
@@ -210,6 +233,14 @@ perform_full_reset() {
         fi
 
         # Check if an agent is actually running in this session
+        if [ -f "$STATUS_DIR/wait/${session_name}.wait" ]; then
+            continue
+        fi
+
+        if [ "$(cat "$status_file" 2>/dev/null)" = "wait" ]; then
+            echo "done" > "$status_file" 2>/dev/null
+        fi
+
         if ! has_agent_in_session "$session_name"; then
             # No agent running, safe to remove stale status
             rm -f "$status_file"

--- a/scripts/next-done-project.sh
+++ b/scripts/next-done-project.sh
@@ -30,19 +30,36 @@ is_ssh_session() {
 }
 
 # Function to get agent status
+normalize_local_wait_status() {
+    local session="$1"
+    local status_file="$STATUS_DIR/${session}.status"
+    local wait_file="$STATUS_DIR/wait/${session}.wait"
+
+    [ ! -f "$status_file" ] && return
+
+    local status
+    status=$(cat "$status_file" 2>/dev/null || echo "")
+    if [ "$status" = "wait" ] && [ ! -f "$wait_file" ]; then
+        echo "done" > "$status_file" 2>/dev/null
+    fi
+}
+
 get_agent_status() {
     local session="$1"
 
     # Check for remote status file first (for SSH sessions)
     local remote_status="$STATUS_DIR/${session}-remote.status"
-    if [ -f "$remote_status" ]; then
+    if [ -f "$remote_status" ] && is_ssh_session "$session"; then
         cat "$remote_status" 2>/dev/null
         return
+    elif [ -f "$remote_status" ] && ! is_ssh_session "$session"; then
+        rm -f "$remote_status" 2>/dev/null
     fi
 
     # Check local status files
     local status_file="$STATUS_DIR/${session}.status"
     if [ -f "$status_file" ]; then
+        normalize_local_wait_status "$session"
         cat "$status_file" 2>/dev/null || echo ""
     else
         echo ""

--- a/scripts/status-line.sh
+++ b/scripts/status-line.sh
@@ -7,6 +7,17 @@ STATUS_DIR="$HOME/.cache/tmux-agent-status"
 LAST_STATUS_FILE="$STATUS_DIR/.last-status-summary"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+is_ssh_session() {
+    local session="$1"
+    if tmux list-panes -t "$session" -F "#{pane_current_command}" 2>/dev/null | grep -q "^ssh$"; then
+        return 0
+    fi
+    case "$session" in
+        reachgpu) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # Check and expire wait timers
 check_wait_timers() {
     local wait_dir="$STATUS_DIR/wait"
@@ -23,6 +34,20 @@ check_wait_timers() {
             rm -f "$wait_file"
         fi
     done
+}
+
+normalize_local_wait_status() {
+    local session="$1"
+    local status_file="$STATUS_DIR/${session}.status"
+    local wait_file="$STATUS_DIR/wait/${session}.wait"
+
+    [ ! -f "$status_file" ] && return
+
+    local status
+    status=$(cat "$status_file" 2>/dev/null || echo "")
+    if [ "$status" = "wait" ] && [ ! -f "$wait_file" ]; then
+        echo "done" > "$status_file" 2>/dev/null
+    fi
 }
 
 # Check for agent processes (Codex) via process polling
@@ -112,7 +137,7 @@ count_agent_status() {
         local status_file="$STATUS_DIR/${session}.status"
 
         # Check if we have any status for this session
-        if [ -f "$remote_status_file" ]; then
+        if [ -f "$remote_status_file" ] && is_ssh_session "$session"; then
             # SSH session with remote status
             local status=$(cat "$remote_status_file" 2>/dev/null)
             if [ -n "$status" ]; then
@@ -123,8 +148,25 @@ count_agent_status() {
                     "wait") ((waiting++)) ;;
                 esac
             fi
+        elif [ -f "$remote_status_file" ] && ! is_ssh_session "$session"; then
+            # A remote cache for a non-SSH session is stale and should not override
+            # the local session status.
+            rm -f "$remote_status_file" 2>/dev/null
+            normalize_local_wait_status "$session"
+            if [ -f "$status_file" ]; then
+                local status=$(cat "$status_file" 2>/dev/null)
+                if [ -n "$status" ]; then
+                    ((total_agents++))
+                    case "$status" in
+                        "working") ((working++)) ;;
+                        "done") ((done++)) ;;
+                        "wait") ((waiting++)) ;;
+                    esac
+                fi
+            fi
         elif [ -f "$status_file" ]; then
             # Local session status
+            normalize_local_wait_status "$session"
             local status=$(cat "$status_file" 2>/dev/null)
             if [ -n "$status" ]; then
                 ((total_agents++))

--- a/smart-monitor.sh
+++ b/smart-monitor.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Smart monitoring daemon that only runs when SSH sessions exist
+# Smart monitoring daemon that runs when SSH sessions or wait timers exist
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATUS_DIR="$HOME/.cache/tmux-agent-status"
@@ -23,6 +23,18 @@ has_ssh_sessions() {
 
     # Also check for known SSH sessions like reachgpu
     tmux list-sessions -F "#{session_name}" 2>/dev/null | grep -q "^reachgpu$"
+}
+
+# Function to check if any wait timers exist
+has_wait_timers() {
+    local wait_dir="$STATUS_DIR/wait"
+    [ ! -d "$wait_dir" ] && return 1
+
+    for wait_file in "$wait_dir"/*.wait; do
+        [ -f "$wait_file" ] && return 0
+    done
+
+    return 1
 }
 
 # Function to check wait timers and move expired sessions back to done
@@ -54,8 +66,8 @@ check_wait_timers() {
 
 # Function to check if daemon should keep running
 should_run() {
-    # Run if tmux is active and has SSH sessions
-    tmux list-sessions >/dev/null 2>&1 && has_ssh_sessions
+    # Run if tmux is active and we need either SSH polling or wait-timer expiry.
+    tmux list-sessions >/dev/null 2>&1 && { has_ssh_sessions || has_wait_timers; }
 }
 
 # Function to update SSH session status

--- a/tests/smart-monitor-wait-expiry.sh
+++ b/tests/smart-monitor-wait-expiry.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEST_HOME="$TMP_DIR/home"
+FAKE_BIN="$TMP_DIR/bin"
+STATUS_DIR="$TEST_HOME/.cache/tmux-agent-status"
+WAIT_DIR="$STATUS_DIR/wait"
+PID_FILE="$STATUS_DIR/smart-monitor.pid"
+
+mkdir -p "$FAKE_BIN" "$WAIT_DIR"
+
+cat > "$FAKE_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    list-sessions)
+        echo "local-session"
+        ;;
+    list-panes)
+        echo "zsh"
+        ;;
+    show-option)
+        echo "none"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+
+    if [ "$expected" != "$actual" ]; then
+        echo "Assertion failed: $message" >&2
+        echo "Expected: $expected" >&2
+        echo "Actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+expiry_time=$(( $(date +%s) - 1 ))
+echo "$expiry_time" > "$WAIT_DIR/local-session.wait"
+echo "wait" > "$STATUS_DIR/local-session.status"
+
+PATH="$FAKE_BIN:$PATH" HOME="$TEST_HOME" "$REPO_DIR/smart-monitor.sh" start
+
+for _ in 1 2 3 4 5; do
+    if [ ! -f "$WAIT_DIR/local-session.wait" ]; then
+        break
+    fi
+    sleep 1
+done
+
+if [ -f "$WAIT_DIR/local-session.wait" ]; then
+    echo "Assertion failed: smart monitor should expire local wait timers without SSH sessions" >&2
+    exit 1
+fi
+
+status_value="$(cat "$STATUS_DIR/local-session.status")"
+assert_eq "done" "$status_value" "expired wait timers should move sessions back to done"
+
+for _ in 1 2 3; do
+    if [ ! -f "$PID_FILE" ]; then
+        break
+    fi
+    sleep 1
+done
+
+if [ -f "$PID_FILE" ]; then
+    echo "Assertion failed: smart monitor should exit once no SSH sessions or wait timers remain" >&2
+    exit 1
+fi
+
+echo "smart-monitor wait expiry regression checks passed"

--- a/tests/status-line-wait-summary.sh
+++ b/tests/status-line-wait-summary.sh
@@ -9,8 +9,9 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 TEST_HOME="$TMP_DIR/home"
 FAKE_BIN="$TMP_DIR/bin"
 STATUS_DIR="$TEST_HOME/.cache/tmux-agent-status"
+WAIT_DIR="$STATUS_DIR/wait"
 
-mkdir -p "$FAKE_BIN" "$STATUS_DIR"
+mkdir -p "$FAKE_BIN" "$STATUS_DIR" "$WAIT_DIR"
 
 cat > "$FAKE_BIN/tmux" <<'EOF'
 #!/usr/bin/env bash
@@ -58,12 +59,24 @@ run_status_line() {
 echo "working" > "$STATUS_DIR/working-session.status"
 echo "wait" > "$STATUS_DIR/wait-session.status"
 echo "done" > "$STATUS_DIR/done-session.status"
+echo "wait" > "$STATUS_DIR/done-session-remote.status"
+echo $(( $(date +%s) + 600 )) > "$WAIT_DIR/wait-session.wait"
 
 summary_output="$(run_status_line)"
 assert_eq "#[fg=yellow,bold]⚡ agent working#[default] #[fg=cyan,bold]⏸ 1 waiting#[default] #[fg=green]✓ 1 done#[default]" "$summary_output" "wait sessions should render as a separate status-bar segment"
+if [ -f "$STATUS_DIR/done-session-remote.status" ]; then
+    echo "Assertion failed: stale remote cache for a non-SSH session should be removed" >&2
+    exit 1
+fi
 
 rm -f "$STATUS_DIR/working-session.status" "$STATUS_DIR/done-session.status"
 wait_only_output="$(run_status_line)"
 assert_eq "#[fg=cyan,bold]⏸ 1 waiting#[default]" "$wait_only_output" "wait-only summaries should not be reported as working"
+
+rm -f "$WAIT_DIR/wait-session.wait"
+stale_wait_output="$(run_status_line)"
+stale_wait_status="$(cat "$STATUS_DIR/wait-session.status")"
+assert_eq "done" "$stale_wait_status" "local wait without a timer should be normalized back to done"
+assert_eq "#[fg=green,bold]✓ All agents ready#[default]" "$stale_wait_output" "stale local wait without a timer should render as done"
 
 echo "status-line wait summary regression checks passed"


### PR DESCRIPTION
## Summary
- keep smart-monitor running while local wait timers exist so wait expiry does not depend on status-bar polling
- normalize orphaned local `wait` states back to `done` when the timer file is missing
- ignore and remove stale `*-remote.status` files for sessions that are no longer SSH sessions
- make full reset clear matching wait statuses as well as timer files
- add regressions for local wait expiry and stale wait/remote cleanup

## Testing
- `bash tests/smart-monitor-wait-expiry.sh`
- `bash tests/status-line-codex-regression.sh`
- `bash tests/status-line-wait-summary.sh`