### PR TITLE
Add parked session state and broaden regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,10 @@ jobs:
           tmux list-keys -T prefix | grep -qE ' -T prefix +y +run-shell .*next-done-project.sh'
           tmux list-keys -T prefix | grep -qE ' -T prefix +z +run-shell .*wait-session.sh'
           tmux kill-server
+
+      - name: Run regression tests
+        run: |
+          set -euo pipefail
+          for test_script in tests/*.sh; do
+            bash "$test_script"
+          done

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ When Codex ships proper event hooks, the plugin will upgrade to hook-based track
 
 Integrate any AI coding tool (Aider, Continue, Cursor, Cline, GitHub Copilot CLI, Goose, Amazon Q, Windsurf, or your own agent):
 
-1. **Status files**: Write `working` or `done` to `~/.cache/tmux-agent-status/<session>.status`
+1. **Status files**: Write `working`, `done`, `wait`, or `parked` to `~/.cache/tmux-agent-status/<session>.status`
 2. **Process polling**: Add your process name to `check_agent_processes()` in `scripts/status-line.sh`
 
 ## Usage
@@ -77,9 +77,11 @@ Integrate any AI coding tool (Aider, Continue, Cursor, Cline, GitHub Copilot CLI
 | `prefix + S` | AI session manager: switcher grouped by agent state |
 | `prefix + N` | Jump to next idle AI session |
 | `prefix + W` | Snooze session (timed wait mode) |
+| `prefix + p` | Park session for later (switcher-only) |
 
 The status bar shows live agent activity:
 - `⚡ agent working` / `⚡ 3 working ✓ 2 done` / `✓ All agents ready`
+- Parked sessions stay visible in the switcher but are hidden from the status bar counts.
 
 ### Keybindings
 
@@ -87,6 +89,7 @@ The status bar shows live agent activity:
 set -g @agent-status-key "s"
 set -g @agent-next-done-key "n"
 set -g @agent-wait-key "w"
+set -g @agent-park-key "p"
 ```
 
 Old `@claude-*` options still work as fallbacks.
@@ -134,7 +137,8 @@ Works with GCP, AWS, Azure, Lambda Labs, or any SSH host.
                                │  "working"       │     ┌──────────────┐
 ┌─────────────┐  status files  │  "done"          ├────►│ prefix + S   │
 │ Custom agent├──────────────►│  "wait"           │     │ switcher     │
-└─────────────┘                └──────────────────┘     └──────────────┘
+└─────────────┘                │  "parked"        │     └──────────────┘
+                               └──────────────────┘
 ```
 
 - **Claude Code**: Hook-based. AI agent reports state transitions directly

--- a/hooks/better-hook.sh
+++ b/hooks/better-hook.sh
@@ -41,12 +41,16 @@ if [ -n "$TMUX" ] || [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
         STATUS_FILE="$STATUS_DIR/${TMUX_SESSION}.status"
         REMOTE_STATUS_FILE="$STATUS_DIR/${TMUX_SESSION}-remote.status"
         WAIT_FILE="$STATUS_DIR/wait/${TMUX_SESSION}.wait"
+        PARKED_FILE="$STATUS_DIR/parked/${TMUX_SESSION}.parked"
 
         case "$HOOK_TYPE" in
             "UserPromptSubmit"|"PreToolUse")
                 # User submitted a prompt or Claude is calling a tool - cancel wait mode if active
                 if [ -f "$WAIT_FILE" ]; then
                     rm -f "$WAIT_FILE"  # Remove wait timer
+                fi
+                if [ -f "$PARKED_FILE" ]; then
+                    rm -f "$PARKED_FILE"
                 fi
                 echo "working" > "$STATUS_FILE"
                 # Only write to remote status file if we're in an SSH session

--- a/scripts/hook-based-switcher.sh
+++ b/scripts/hook-based-switcher.sh
@@ -4,19 +4,13 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATUS_DIR="$HOME/.cache/tmux-agent-status"
+PARKED_DIR="$STATUS_DIR/parked"
+# shellcheck source=lib/agent-processes.sh
+source "$SCRIPT_DIR/lib/agent-processes.sh"
 
 # Function to check if an agent (Claude or Codex) is in a session
 has_agent_in_session() {
-    local session="$1"
-
-    # Check all panes in the session for agent processes
-    while IFS=: read -r pane_id pane_pid; do
-        if pgrep -P "$pane_pid" -f "claude|codex" >/dev/null 2>&1; then
-            return 0  # Found agent process
-        fi
-    done < <(tmux list-panes -t "$session" -F "#{pane_id}:#{pane_pid}" 2>/dev/null)
-
-    return 1  # No agent process found
+    session_has_agent_process "$1"
 }
 
 # Function to check if session is SSH by examining panes
@@ -62,6 +56,11 @@ normalize_local_wait_status() {
 get_agent_status() {
     local session="$1"
 
+    if [ -f "$PARKED_DIR/${session}.parked" ]; then
+        echo "parked"
+        return
+    fi
+
     # Check for remote status file first (for SSH sessions)
     local remote_status="$STATUS_DIR/${session}-remote.status"
     if [ -f "$remote_status" ] && is_ssh_session "$session"; then
@@ -86,6 +85,7 @@ get_sessions_with_status() {
     local working_sessions=()
     local done_sessions=()
     local wait_sessions=()
+    local parked_sessions=()
     local no_agent_sessions=()
 
     # Collect all sessions into arrays
@@ -103,6 +103,8 @@ get_sessions_with_status() {
         local has_agent=false
 
         if has_agent_in_session "$name"; then
+            has_agent=true
+        elif [ "$agent_status" = "parked" ]; then
             has_agent=true
         elif [ -n "$agent_status" ] && is_ssh_session "$name"; then
             # SSH session with remote status
@@ -144,6 +146,13 @@ get_sessions_with_status() {
                     formatted_line=$(printf "%-20s %2s windows %-12s [wait] %s" "$name" "$windows" "$attached" "$wait_info")
                 fi
                 wait_sessions+=("$formatted_line")
+            elif [ "$agent_status" = "parked" ]; then
+                if [ -n "$ssh_indicator" ]; then
+                    formatted_line=$(printf "%-20s %2s windows %-12s %s [parked]" "$name" "$windows" "$attached" "$ssh_indicator")
+                else
+                    formatted_line=$(printf "%-20s %2s windows %-12s [parked]" "$name" "$windows" "$attached")
+                fi
+                parked_sessions+=("$formatted_line")
             else
                 if [ -n "$ssh_indicator" ]; then
                     formatted_line=$(printf "%-20s %2s windows %-12s %s [done]" "$name" "$windows" "$attached" "$ssh_indicator")
@@ -184,9 +193,16 @@ get_sessions_with_status() {
         printf '%s\n' "${wait_sessions[@]}"
     fi
 
+    # Parked sessions
+    if [ ${#parked_sessions[@]} -gt 0 ]; then
+        [ ${#working_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] && echo
+        echo -e "\033[1;35m PARKED \033[0m"
+        printf '%s\n' "${parked_sessions[@]}"
+    fi
+
     # No agent sessions
     if [ ${#no_agent_sessions[@]} -gt 0 ]; then
-        [ ${#working_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] && echo
+        [ ${#working_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] || [ ${#parked_sessions[@]} -gt 0 ] && echo
         echo -e "\033[1;90m NO AGENT \033[0m"
         printf '%s\n' "${no_agent_sessions[@]}"
     fi
@@ -217,6 +233,19 @@ perform_full_reset() {
         rm -f "$wait_file" 2>/dev/null
     done
 
+    # Clear parked markers and normalize matching parked statuses back to done
+    for parked_file in "$PARKED_DIR"/*.parked; do
+        [ ! -f "$parked_file" ] && continue
+        session_name=$(basename "$parked_file" .parked)
+        if [ -f "$STATUS_DIR/${session_name}.status" ] && [ "$(cat "$STATUS_DIR/${session_name}.status" 2>/dev/null)" = "parked" ]; then
+            echo "done" > "$STATUS_DIR/${session_name}.status" 2>/dev/null
+        fi
+        if [ -f "$STATUS_DIR/${session_name}-remote.status" ] && [ "$(cat "$STATUS_DIR/${session_name}-remote.status" 2>/dev/null)" = "parked" ]; then
+            echo "done" > "$STATUS_DIR/${session_name}-remote.status" 2>/dev/null
+        fi
+        rm -f "$parked_file" 2>/dev/null
+    done
+
     # Clear temp files
     rm -f "$STATUS_DIR"/.*.status.tmp 2>/dev/null
 
@@ -237,7 +266,8 @@ perform_full_reset() {
             continue
         fi
 
-        if [ "$(cat "$status_file" 2>/dev/null)" = "wait" ]; then
+        status_value=$(cat "$status_file" 2>/dev/null)
+        if [ "$status_value" = "wait" ] || [ "$status_value" = "parked" ]; then
             echo "done" > "$status_file" 2>/dev/null
         fi
 

--- a/scripts/lib/agent-processes.sh
+++ b/scripts/lib/agent-processes.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Shared helpers for finding Claude/Codex processes inside tmux sessions.
+
+find_matching_descendant_pid() {
+    local root_pid="$1"
+    local pattern="${2:-claude|codex}"
+    local process_args=""
+
+    process_args=$(ps -p "$root_pid" -o args= 2>/dev/null || true)
+    if [ -n "$process_args" ] && [[ "$process_args" =~ (^|[[:space:]/])($pattern)([[:space:]]|$) ]]; then
+        echo "$root_pid"
+        return 0
+    fi
+
+    while IFS= read -r child_pid; do
+        [ -z "$child_pid" ] && continue
+
+        local match_pid=""
+        match_pid=$(find_matching_descendant_pid "$child_pid" "$pattern")
+        if [ -n "$match_pid" ]; then
+            echo "$match_pid"
+            return 0
+        fi
+    done < <(pgrep -P "$root_pid" 2>/dev/null || true)
+
+    return 1
+}
+
+find_session_agent_pid() {
+    local session="$1"
+    local pattern="${2:-claude|codex}"
+
+    while IFS=: read -r _ pane_pid; do
+        [ -z "$pane_pid" ] && continue
+
+        local match_pid=""
+        match_pid=$(find_matching_descendant_pid "$pane_pid" "$pattern")
+        if [ -n "$match_pid" ]; then
+            echo "$match_pid"
+            return 0
+        fi
+    done < <(tmux list-panes -t "$session" -F "#{pane_id}:#{pane_pid}" 2>/dev/null)
+
+    return 1
+}
+
+session_has_agent_process() {
+    local session="$1"
+    local pattern="${2:-claude|codex}"
+
+    find_session_agent_pid "$session" "$pattern" >/dev/null 2>&1
+}

--- a/scripts/next-done-project.sh
+++ b/scripts/next-done-project.sh
@@ -3,18 +3,14 @@
 # Find and switch to the next 'done' project
 
 STATUS_DIR="$HOME/.cache/tmux-agent-status"
+PARKED_DIR="$STATUS_DIR/parked"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/agent-processes.sh
+source "$SCRIPT_DIR/lib/agent-processes.sh"
 
 # Function to check if an agent is in a session
 has_agent_in_session() {
-    local session="$1"
-
-    while IFS=: read -r pane_id pane_pid; do
-        if pgrep -P "$pane_pid" -f "claude|codex" >/dev/null 2>&1; then
-            return 0
-        fi
-    done < <(tmux list-panes -t "$session" -F "#{pane_id}:#{pane_pid}" 2>/dev/null)
-
-    return 1
+    session_has_agent_process "$1"
 }
 
 # Function to check if session is SSH
@@ -46,6 +42,11 @@ normalize_local_wait_status() {
 
 get_agent_status() {
     local session="$1"
+
+    if [ -f "$PARKED_DIR/${session}.parked" ]; then
+        echo "parked"
+        return
+    fi
 
     # Check for remote status file first (for SSH sessions)
     local remote_status="$STATUS_DIR/${session}-remote.status"
@@ -91,14 +92,14 @@ while IFS=: read -r name windows attached; do
 
         if [ "$agent_status" = "done" ] && [ "$name" != "$exclude_session" ]; then
             # Get completion time from status file modification time
-            local status_file=""
+            status_file=""
             if is_ssh_session "$name"; then
                 status_file="$STATUS_DIR/${name}-remote.status"
             else
                 status_file="$STATUS_DIR/${name}.status"
             fi
 
-            local completion_time=0
+            completion_time=0
             if [ -f "$status_file" ]; then
                 completion_time=$(stat -c %Y "$status_file" 2>/dev/null || echo 0)
             fi
@@ -115,7 +116,7 @@ done_sessions=("${sorted_sessions[@]}")
 # If no done sessions, exit
 if [ ${#done_sessions[@]} -eq 0 ]; then
     tmux display-message "No done projects found"
-    exit 0
+    exit 1
 fi
 
 # Find current session index in done sessions

--- a/scripts/park-session.sh
+++ b/scripts/park-session.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 
-# Put current session in wait mode with a timer
+# Park the current session so it stays in the switcher but drops out of the toolbar.
 
 STATUS_DIR="$HOME/.cache/tmux-agent-status"
 WAIT_DIR="$STATUS_DIR/wait"
+PARKED_DIR="$STATUS_DIR/parked"
+mkdir -p "$PARKED_DIR"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/agent-processes.sh
 source "$SCRIPT_DIR/lib/agent-processes.sh"
 
-# Get current session
 current_session=$(tmux display-message -p "#{session_name}")
 
-# Check if session has an agent
 has_agent_in_session() {
     session_has_agent_process "$1"
 }
 
-# Check if session is SSH
 is_ssh_session() {
     local session="$1"
     if tmux list-panes -t "$session" -F "#{pane_current_command}" 2>/dev/null | grep -q "^ssh$"; then
@@ -28,15 +28,27 @@ is_ssh_session() {
     esac
 }
 
-# Check if session has an agent or is SSH session
 if ! has_agent_in_session "$current_session" && ! is_ssh_session "$current_session"; then
-    # Also check if session has a status file (might be from a finished agent)
     if [ ! -f "$STATUS_DIR/${current_session}.status" ] && [ ! -f "$STATUS_DIR/${current_session}-remote.status" ]; then
-        tmux display-message "Session $current_session has no agent running"
+        tmux display-message "Session $current_session has no agent state to park"
         exit 1
     fi
 fi
 
-# Prompt for wait time using command-prompt
-# This will call our handler script with the session name and wait time
-tmux command-prompt -p "Wait time in minutes:" "run-shell '$SCRIPT_DIR/wait-session-handler.sh \"$current_session\" %1'"
+rm -f "$WAIT_DIR/$current_session.wait"
+: > "$PARKED_DIR/$current_session.parked"
+
+if is_ssh_session "$current_session"; then
+    echo "parked" > "$STATUS_DIR/${current_session}-remote.status"
+else
+    echo "parked" > "$STATUS_DIR/${current_session}.status"
+fi
+
+NEXT_DONE_SCRIPT="$SCRIPT_DIR/next-done-project.sh"
+if [ -f "$NEXT_DONE_SCRIPT" ]; then
+    if ! bash "$NEXT_DONE_SCRIPT" "$current_session" 2>/dev/null; then
+        tmux display-message "Session $current_session parked for later"
+    fi
+else
+    tmux display-message "Session $current_session parked for later"
+fi

--- a/scripts/status-line.sh
+++ b/scripts/status-line.sh
@@ -4,8 +4,11 @@
 # Shows agent status across all sessions
 
 STATUS_DIR="$HOME/.cache/tmux-agent-status"
+PARKED_DIR="$STATUS_DIR/parked"
 LAST_STATUS_FILE="$STATUS_DIR/.last-status-summary"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/agent-processes.sh
+source "$SCRIPT_DIR/lib/agent-processes.sh"
 
 is_ssh_session() {
     local session="$1"
@@ -57,18 +60,7 @@ normalize_local_wait_status() {
 # The notify hook handles the "working" -> "done" transition.
 # We detect active work by checking if codex has child processes (sandbox/tools).
 find_session_codex_pid() {
-    local session="$1"
-
-    while IFS=: read -r pane_id pane_pid; do
-        local found_pid
-        found_pid=$(pgrep -P "$pane_pid" -f "codex" 2>/dev/null | head -1)
-        if [ -n "$found_pid" ]; then
-            echo "$found_pid"
-            return 0
-        fi
-    done < <(tmux list-panes -t "$session" -F "#{pane_id}:#{pane_pid}" 2>/dev/null)
-
-    return 1
+    find_session_agent_pid "$1" "codex"
 }
 
 get_deepest_codex_pid() {
@@ -101,18 +93,36 @@ check_agent_processes() {
     while IFS= read -r session; do
         [ -z "$session" ] && continue
         local status_file="$STATUS_DIR/${session}.status"
+        local wait_file="$STATUS_DIR/wait/${session}.wait"
+        local parked_file="$PARKED_DIR/${session}.parked"
         local codex_pid=""
 
         codex_pid=$(find_session_codex_pid "$session" 2>/dev/null)
 
         if [ -n "$codex_pid" ]; then
             local current_status
-            current_status=$(cat "$status_file" 2>/dev/null)
+            if [ -f "$parked_file" ]; then
+                current_status="parked"
+            else
+                current_status=$(cat "$status_file" 2>/dev/null)
+            fi
             if [ -z "$current_status" ]; then
                 # No status file yet - first detection, assume working
                 echo "working" > "$status_file"
-            elif [ "$current_status" = "done" ] && codex_session_is_working "$codex_pid"; then
-                echo "working" > "$status_file"
+            elif codex_session_is_working "$codex_pid"; then
+                case "$current_status" in
+                    "done")
+                        echo "working" > "$status_file"
+                        ;;
+                    "wait")
+                        rm -f "$wait_file"
+                        echo "working" > "$status_file"
+                        ;;
+                    "parked")
+                        rm -f "$parked_file"
+                        echo "working" > "$status_file"
+                        ;;
+                esac
             fi
         fi
     done < <(tmux list-sessions -F "#{session_name}" 2>/dev/null)
@@ -132,6 +142,11 @@ count_agent_status() {
     while IFS= read -r session; do
         [ -z "$session" ] && continue
 
+        local parked_file="$PARKED_DIR/${session}.parked"
+        if [ -f "$parked_file" ]; then
+            continue
+        fi
+
         # Check for SSH remote status file (e.g., reachgpu-remote.status)
         local remote_status_file="$STATUS_DIR/${session}-remote.status"
         local status_file="$STATUS_DIR/${session}.status"
@@ -141,11 +156,10 @@ count_agent_status() {
             # SSH session with remote status
             local status=$(cat "$remote_status_file" 2>/dev/null)
             if [ -n "$status" ]; then
-                ((total_agents++))
                 case "$status" in
-                    "working") ((working++)) ;;
-                    "done") ((done++)) ;;
-                    "wait") ((waiting++)) ;;
+                    "working") ((working++)); ((total_agents++)) ;;
+                    "done") ((done++)); ((total_agents++)) ;;
+                    "wait") ((waiting++)); ((total_agents++)) ;;
                 esac
             fi
         elif [ -f "$remote_status_file" ] && ! is_ssh_session "$session"; then
@@ -156,11 +170,10 @@ count_agent_status() {
             if [ -f "$status_file" ]; then
                 local status=$(cat "$status_file" 2>/dev/null)
                 if [ -n "$status" ]; then
-                    ((total_agents++))
                     case "$status" in
-                        "working") ((working++)) ;;
-                        "done") ((done++)) ;;
-                        "wait") ((waiting++)) ;;
+                        "working") ((working++)); ((total_agents++)) ;;
+                        "done") ((done++)); ((total_agents++)) ;;
+                        "wait") ((waiting++)); ((total_agents++)) ;;
                     esac
                 fi
             fi
@@ -169,11 +182,10 @@ count_agent_status() {
             normalize_local_wait_status "$session"
             local status=$(cat "$status_file" 2>/dev/null)
             if [ -n "$status" ]; then
-                ((total_agents++))
                 case "$status" in
-                    "working") ((working++)) ;;
-                    "done") ((done++)) ;;
-                    "wait") ((waiting++)) ;;
+                    "working") ((working++)); ((total_agents++)) ;;
+                    "done") ((done++)); ((total_agents++)) ;;
+                    "wait") ((waiting++)); ((total_agents++)) ;;
                 esac
             fi
         fi

--- a/scripts/wait-session-handler.sh
+++ b/scripts/wait-session-handler.sh
@@ -4,6 +4,7 @@
 
 STATUS_DIR="$HOME/.cache/tmux-agent-status"
 WAIT_DIR="$STATUS_DIR/wait"
+PARKED_DIR="$STATUS_DIR/parked"
 mkdir -p "$WAIT_DIR"
 
 current_session="$1"
@@ -23,6 +24,9 @@ echo "$expiry_time" > "$WAIT_DIR/$current_session.wait"
 
 # Small delay to ensure wait file is written
 sync
+
+# Wait mode overrides any parked marker.
+rm -f "$PARKED_DIR/$current_session.parked"
 
 # Set session status to wait
 # Check if it's an SSH session by looking for remote status file

--- a/smart-monitor.sh
+++ b/smart-monitor.sh
@@ -4,6 +4,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATUS_DIR="$HOME/.cache/tmux-agent-status"
+PARKED_DIR="$STATUS_DIR/parked"
 DAEMON_PID_FILE="$STATUS_DIR/smart-monitor.pid"
 
 # Function to check if any SSH sessions exist
@@ -75,16 +76,21 @@ update_ssh_status() {
     # Update reachgpu status
     if tmux has-session -t reachgpu 2>/dev/null; then
         local temp_file="$STATUS_DIR/.reachgpu-remote.status.tmp"
+        local wait_file="$STATUS_DIR/wait/reachgpu.wait"
+        local parked_file="$PARKED_DIR/reachgpu.parked"
         if ssh -o ConnectTimeout=2 -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET \
             reachgpu "cat ~/.cache/tmux-agent-status/reachgpu.status 2>/dev/null || echo ''" \
             > "$temp_file" 2>/dev/null; then
             local remote_status=$(cat "$temp_file")
             # If remote agent is working, cancel local wait mode
-            if [ "$remote_status" = "working" ] && [ -f "$STATUS_DIR/wait/reachgpu.wait" ]; then
-                rm -f "$STATUS_DIR/wait/reachgpu.wait"
+            if [ "$remote_status" = "working" ] && [ -f "$wait_file" ]; then
+                rm -f "$wait_file"
             fi
-            # Don't overwrite local wait status at all
-            if [ ! -f "$STATUS_DIR/wait/reachgpu.wait" ]; then
+            if [ "$remote_status" = "working" ] && [ -f "$parked_file" ]; then
+                rm -f "$parked_file"
+            fi
+            # Don't overwrite local wait or parked overrides.
+            if [ ! -f "$wait_file" ] && [ ! -f "$parked_file" ]; then
                 mv "$temp_file" "$STATUS_DIR/reachgpu-remote.status"
             else
                 rm -f "$temp_file"
@@ -97,16 +103,21 @@ update_ssh_status() {
     # Update tig status
     if tmux has-session -t tig 2>/dev/null; then
         local temp_file="$STATUS_DIR/.tig-remote.status.tmp"
+        local wait_file="$STATUS_DIR/wait/tig.wait"
+        local parked_file="$PARKED_DIR/tig.parked"
         if ssh -o ConnectTimeout=2 -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET \
             nga100 "cat ~/.cache/tmux-agent-status/tig.status 2>/dev/null || echo ''" \
             > "$temp_file" 2>/dev/null; then
             local remote_status=$(cat "$temp_file")
             # If remote agent is working, cancel local wait mode
-            if [ "$remote_status" = "working" ] && [ -f "$STATUS_DIR/wait/tig.wait" ]; then
-                rm -f "$STATUS_DIR/wait/tig.wait"
+            if [ "$remote_status" = "working" ] && [ -f "$wait_file" ]; then
+                rm -f "$wait_file"
             fi
-            # Don't overwrite local wait status at all
-            if [ ! -f "$STATUS_DIR/wait/tig.wait" ]; then
+            if [ "$remote_status" = "working" ] && [ -f "$parked_file" ]; then
+                rm -f "$parked_file"
+            fi
+            # Don't overwrite local wait or parked overrides.
+            if [ ! -f "$wait_file" ] && [ ! -f "$parked_file" ]; then
                 mv "$temp_file" "$STATUS_DIR/tig-remote.status"
             else
                 rm -f "$temp_file"
@@ -119,16 +130,21 @@ update_ssh_status() {
     # Update l4-workstation status
     if tmux has-session -t l4-workstation 2>/dev/null; then
         local temp_file="$STATUS_DIR/.l4-workstation-remote.status.tmp"
+        local wait_file="$STATUS_DIR/wait/l4-workstation.wait"
+        local parked_file="$PARKED_DIR/l4-workstation.parked"
         if ssh -o ConnectTimeout=2 -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET \
             l4-workstation "cat ~/.cache/tmux-agent-status/l4-workstation.status 2>/dev/null || echo ''" \
             > "$temp_file" 2>/dev/null; then
             local remote_status=$(cat "$temp_file")
             # If remote agent is working, cancel local wait mode
-            if [ "$remote_status" = "working" ] && [ -f "$STATUS_DIR/wait/l4-workstation.wait" ]; then
-                rm -f "$STATUS_DIR/wait/l4-workstation.wait"
+            if [ "$remote_status" = "working" ] && [ -f "$wait_file" ]; then
+                rm -f "$wait_file"
             fi
-            # Don't overwrite local wait status at all
-            if [ ! -f "$STATUS_DIR/wait/l4-workstation.wait" ]; then
+            if [ "$remote_status" = "working" ] && [ -f "$parked_file" ]; then
+                rm -f "$parked_file"
+            fi
+            # Don't overwrite local wait or parked overrides.
+            if [ ! -f "$wait_file" ] && [ ! -f "$parked_file" ]; then
                 mv "$temp_file" "$STATUS_DIR/l4-workstation-remote.status"
             else
                 rm -f "$temp_file"

--- a/tests/nested-codex-detection.sh
+++ b/tests/nested-codex-detection.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEST_HOME="$TMP_DIR/home"
+FAKE_BIN="$TMP_DIR/bin"
+STATUS_DIR="$TEST_HOME/.cache/tmux-agent-status"
+
+mkdir -p "$FAKE_BIN" "$STATUS_DIR"
+
+cat > "$FAKE_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    list-sessions)
+        case "${3:-}" in
+            "#{session_name}")
+                echo "wrapped-codex"
+                ;;
+            "#{session_name}:#{session_windows}:#{?session_attached,(attached),}")
+                echo "wrapped-codex:1:"
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+    list-panes)
+        case "${5:-}" in
+            "#{pane_id}:#{pane_pid}")
+                echo "%1:100"
+                ;;
+            "#{pane_current_command}")
+                echo "zsh"
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+cat > "$FAKE_BIN/pgrep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args="$*"
+
+case "$args" in
+    "-P 100")
+        echo "101"
+        ;;
+    "-P 101")
+        echo "102"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/pgrep"
+
+cat > "$FAKE_BIN/ps" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "-p" ] || [ "${3:-}" != "-o" ] || [ "${4:-}" != "args=" ]; then
+    exit 1
+fi
+
+case "${2:-}" in
+    100)
+        echo "-zsh"
+        ;;
+    101)
+        echo "/usr/bin/zsh"
+        ;;
+    102)
+        echo "node /home/test/.nvm/versions/node/v24.12.0/bin/codex"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/ps"
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+
+    if [ "$expected" != "$actual" ]; then
+        echo "Assertion failed: $message" >&2
+        echo "Expected: $expected" >&2
+        echo "Actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+run_status_line() {
+    PATH="$FAKE_BIN:$PATH" \
+    HOME="$TEST_HOME" \
+    "$REPO_DIR/scripts/status-line.sh"
+}
+
+run_switcher() {
+    PATH="$FAKE_BIN:$PATH" \
+    HOME="$TEST_HOME" \
+    "$REPO_DIR/scripts/hook-based-switcher.sh" --no-fzf
+}
+
+status_line_output="$(run_status_line)"
+status_value="$(cat "$STATUS_DIR/wrapped-codex.status")"
+assert_eq "working" "$status_value" "nested shell wrappers should still be detected as Codex sessions"
+assert_eq "#[fg=yellow,bold]⚡ agent working#[default]" "$status_line_output" "nested Codex sessions should render as working"
+
+rm -f "$STATUS_DIR/wrapped-codex.status"
+switcher_output="$(run_switcher)"
+if ! printf '%s\n' "$switcher_output" | grep -Fq "wrapped-codex"; then
+    echo "Assertion failed: switcher should include the wrapped Codex session" >&2
+    exit 1
+fi
+if ! printf '%s\n' "$switcher_output" | grep -Fq "[done]"; then
+    echo "Assertion failed: switcher should treat wrapped Codex sessions as agents, not no-agent sessions" >&2
+    exit 1
+fi
+if printf '%s\n' "$switcher_output" | grep -Fq "[no agent]"; then
+    echo "Assertion failed: wrapped Codex sessions should not fall into the no-agent bucket" >&2
+    exit 1
+fi
+
+echo "nested Codex detection regression checks passed"

--- a/tests/parked-codex-reactivation.sh
+++ b/tests/parked-codex-reactivation.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEST_HOME="$TMP_DIR/home"
+FAKE_BIN="$TMP_DIR/bin"
+STATUS_DIR="$TEST_HOME/.cache/tmux-agent-status"
+PARKED_DIR="$STATUS_DIR/parked"
+
+mkdir -p "$FAKE_BIN" "$STATUS_DIR" "$PARKED_DIR"
+
+cat > "$FAKE_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    list-sessions)
+        case "${3:-}" in
+            "#{session_name}")
+                echo "parked-codex"
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+    list-panes)
+        case "${5:-}" in
+            "#{pane_id}:#{pane_pid}")
+                echo "%1:100"
+                ;;
+            "#{pane_current_command}")
+                echo "zsh"
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+cat > "$FAKE_BIN/pgrep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args="$*"
+
+case "$args" in
+    "-P 100")
+        echo "101"
+        ;;
+    "-P 101")
+        echo "102"
+        ;;
+    "-P 102 -f codex")
+        exit 1
+        ;;
+    "-P 102")
+        echo "103"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/pgrep"
+
+cat > "$FAKE_BIN/ps" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "-p" ] || [ "${3:-}" != "-o" ] || [ "${4:-}" != "args=" ]; then
+    exit 1
+fi
+
+case "${2:-}" in
+    100)
+        echo "-zsh"
+        ;;
+    101)
+        echo "/usr/bin/zsh"
+        ;;
+    102)
+        echo "node /home/test/.nvm/versions/node/v24.12.0/bin/codex"
+        ;;
+    103)
+        echo "sandbox helper"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/ps"
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+
+    if [ "$expected" != "$actual" ]; then
+        echo "Assertion failed: $message" >&2
+        echo "Expected: $expected" >&2
+        echo "Actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+run_status_line() {
+    PATH="$FAKE_BIN:$PATH" \
+    HOME="$TEST_HOME" \
+    "$REPO_DIR/scripts/status-line.sh"
+}
+
+echo "parked" > "$STATUS_DIR/parked-codex.status"
+: > "$PARKED_DIR/parked-codex.parked"
+
+status_line_output="$(run_status_line)"
+status_value="$(cat "$STATUS_DIR/parked-codex.status")"
+assert_eq "working" "$status_value" "active Codex work should reactivate parked sessions"
+assert_eq "#[fg=yellow,bold]⚡ agent working#[default]" "$status_line_output" "reactivated parked Codex sessions should render as working"
+
+if [ -f "$PARKED_DIR/parked-codex.parked" ]; then
+    echo "Assertion failed: parked marker should be cleared when Codex becomes active" >&2
+    exit 1
+fi
+
+echo "parked Codex reactivation regression checks passed"

--- a/tests/status-line-codex-regression.sh
+++ b/tests/status-line-codex-regression.sh
@@ -37,7 +37,7 @@ set -euo pipefail
 args="$*"
 
 case "$args" in
-    "-P 4242 -f codex")
+    "-P 4242")
         echo "5000"
         ;;
     "-P 5000 -f codex")
@@ -56,6 +56,31 @@ case "$args" in
 esac
 EOF
 chmod +x "$FAKE_BIN/pgrep"
+
+cat > "$FAKE_BIN/ps" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "-p" ] || [ "${3:-}" != "-o" ] || [ "${4:-}" != "args=" ]; then
+    exit 1
+fi
+
+case "${2:-}" in
+    4242)
+        echo "-zsh"
+        ;;
+    5000)
+        echo "node /home/test/.nvm/versions/node/v24.12.0/bin/codex"
+        ;;
+    5001)
+        echo "/home/test/.nvm/versions/node/v24.12.0/lib/node_modules/@openai/codex/vendor/codex"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/ps"
 
 assert_eq() {
     local expected="$1"

--- a/tests/status-line-codex-regression.sh
+++ b/tests/status-line-codex-regression.sh
@@ -23,6 +23,13 @@ case "${1:-}" in
     list-panes)
         echo "%1:4242"
         ;;
+    show-option)
+        if [ "${3:-}" = "@agent-notification-sound" ] || [ "${3:-}" = "@claude-notification-sound" ]; then
+            echo "none"
+            exit 0
+        fi
+        exit 0
+        ;;
     *)
         exit 1
         ;;

--- a/tests/status-line-parked-summary.sh
+++ b/tests/status-line-parked-summary.sh
@@ -31,6 +31,13 @@ case "${1:-}" in
     list-panes)
         exit 0
         ;;
+    show-option)
+        if [ "${3:-}" = "@agent-notification-sound" ] || [ "${3:-}" = "@claude-notification-sound" ]; then
+            echo "none"
+            exit 0
+        fi
+        exit 0
+        ;;
     *)
         exit 1
         ;;

--- a/tests/status-line-parked-summary.sh
+++ b/tests/status-line-parked-summary.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEST_HOME="$TMP_DIR/home"
+FAKE_BIN="$TMP_DIR/bin"
+STATUS_DIR="$TEST_HOME/.cache/tmux-agent-status"
+PARKED_DIR="$STATUS_DIR/parked"
+
+mkdir -p "$FAKE_BIN" "$STATUS_DIR" "$PARKED_DIR"
+
+cat > "$FAKE_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    list-sessions)
+        case "${3:-}" in
+            "#{session_name}")
+                printf '%s\n' "parked-session" "done-session"
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+    list-panes)
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+cat > "$FAKE_BIN/pgrep" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$FAKE_BIN/pgrep"
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+
+    if [ "$expected" != "$actual" ]; then
+        echo "Assertion failed: $message" >&2
+        echo "Expected: $expected" >&2
+        echo "Actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+run_status_line() {
+    PATH="$FAKE_BIN:$PATH" \
+    HOME="$TEST_HOME" \
+    "$REPO_DIR/scripts/status-line.sh"
+}
+
+echo "parked" > "$STATUS_DIR/parked-session.status"
+: > "$PARKED_DIR/parked-session.parked"
+echo "done" > "$STATUS_DIR/done-session.status"
+
+summary_output="$(run_status_line)"
+assert_eq "#[fg=green,bold]✓ All agents ready#[default]" "$summary_output" "parked sessions should be excluded from the status-bar summary"
+
+rm -f "$STATUS_DIR/done-session.status"
+parked_only_output="$(run_status_line)"
+assert_eq "" "$parked_only_output" "parked-only sessions should render nothing in the status bar"
+
+echo "status-line parked summary regression checks passed"

--- a/tests/status-line-wait-summary.sh
+++ b/tests/status-line-wait-summary.sh
@@ -24,6 +24,13 @@ case "${1:-}" in
     list-panes)
         exit 0
         ;;
+    show-option)
+        if [ "${3:-}" = "@agent-notification-sound" ] || [ "${3:-}" = "@claude-notification-sound" ]; then
+            echo "none"
+            exit 0
+        fi
+        exit 0
+        ;;
     *)
         exit 1
         ;;

--- a/tests/switcher-parked-group.sh
+++ b/tests/switcher-parked-group.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEST_HOME="$TMP_DIR/home"
+FAKE_BIN="$TMP_DIR/bin"
+STATUS_DIR="$TEST_HOME/.cache/tmux-agent-status"
+PARKED_DIR="$STATUS_DIR/parked"
+
+mkdir -p "$FAKE_BIN" "$STATUS_DIR" "$PARKED_DIR"
+
+cat > "$FAKE_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    list-sessions)
+        case "${3:-}" in
+            "#{session_name}:#{session_windows}:#{?session_attached,(attached),}")
+                echo "parked-task:1:"
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+    list-panes)
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+echo "parked" > "$STATUS_DIR/parked-task.status"
+: > "$PARKED_DIR/parked-task.parked"
+
+switcher_output="$(PATH="$FAKE_BIN:$PATH" HOME="$TEST_HOME" "$REPO_DIR/scripts/hook-based-switcher.sh" --no-fzf)"
+
+if ! printf '%s\n' "$switcher_output" | grep -Fq "PARKED"; then
+    echo "Assertion failed: switcher should render a PARKED section" >&2
+    exit 1
+fi
+if ! printf '%s\n' "$switcher_output" | grep -Fq "[parked]"; then
+    echo "Assertion failed: switcher should label parked sessions explicitly" >&2
+    exit 1
+fi
+if printf '%s\n' "$switcher_output" | grep -Fq "[no agent]"; then
+    echo "Assertion failed: parked sessions should not fall into the no-agent bucket" >&2
+    exit 1
+fi
+
+echo "switcher parked grouping regression checks passed"

--- a/tmux-agent-status.tmux
+++ b/tmux-agent-status.tmux
@@ -13,6 +13,7 @@ fi
 default_switcher_key="S"
 default_next_done_key="N"
 default_wait_key="W"
+default_park_key="p"
 
 # Get user configuration or use defaults (check new @agent-* first, fall back to @claude-*)
 switcher_key=$(tmux show-option -gqv "@agent-status-key")
@@ -21,10 +22,13 @@ next_done_key=$(tmux show-option -gqv "@agent-next-done-key")
 [ -z "$next_done_key" ] && next_done_key=$(tmux show-option -gqv "@claude-next-done-key")
 wait_key=$(tmux show-option -gqv "@agent-wait-key")
 [ -z "$wait_key" ] && wait_key=$(tmux show-option -gqv "@claude-wait-key")
+park_key=$(tmux show-option -gqv "@agent-park-key")
+[ -z "$park_key" ] && park_key=$(tmux show-option -gqv "@claude-park-key")
 
 [ -z "$switcher_key" ] && switcher_key="$default_switcher_key"
 [ -z "$next_done_key" ] && next_done_key="$default_next_done_key"
 [ -z "$wait_key" ] && wait_key="$default_wait_key"
+[ -z "$park_key" ] && park_key="$default_park_key"
 
 # Set up custom session switcher with agent status (hook-based)
 tmux bind-key "$switcher_key" display-popup -E -w 80% -h 70% "$CURRENT_DIR/scripts/hook-based-switcher.sh"
@@ -34,6 +38,9 @@ tmux bind-key "$next_done_key" run-shell "$CURRENT_DIR/scripts/next-done-project
 
 # Set up keybinding to put session in wait mode
 tmux bind-key "$wait_key" run-shell "$CURRENT_DIR/scripts/wait-session.sh"
+
+# Set up keybinding to park a session for later
+tmux bind-key "$park_key" run-shell "$CURRENT_DIR/scripts/park-session.sh"
 
 # Detect iTerm2 Control Mode (tmux -CC) and skip status polling / daemons
 # to avoid interfering with the control protocol. Keybindings above are fine.


### PR DESCRIPTION
## Summary
- add a parked session state with a `prefix + p` binding
- keep parked sessions visible in the switcher while excluding them from the status bar summary and done rotation
- fold in the shared agent-process detection, nested Codex coverage, and CI regression sweep already present in the worktree

## Testing
- bash -n tmux-agent-status.tmux scripts/status-line.sh scripts/hook-based-switcher.sh scripts/next-done-project.sh scripts/wait-session-handler.sh scripts/park-session.sh hooks/better-hook.sh smart-monitor.sh tests/status-line-parked-summary.sh tests/parked-codex-reactivation.sh tests/switcher-parked-group.sh
- tests/status-line-parked-summary.sh
- tests/parked-codex-reactivation.sh
- tests/switcher-parked-group.sh
- tests/status-line-wait-summary.sh
- bash tests/nested-codex-detection.sh
- tests/status-line-codex-regression.sh
- tests/smart-monitor-wait-expiry.sh