### PR TITLE
Preserve parked sessions when clearing switcher caches

### DIFF
--- a/scripts/hook-based-switcher.sh
+++ b/scripts/hook-based-switcher.sh
@@ -220,7 +220,7 @@ perform_full_reset() {
     pkill -f "daemon-monitor.sh" 2>/dev/null
     pkill -f "smart-monitor.sh" 2>/dev/null
 
-    # Clear only stale cache files, not active working status
+    # Clear stale caches and reset wait timers, but preserve explicit parked state.
     # Clear PID files
     find "$STATUS_DIR" -type f -name "*.pid" -delete 2>/dev/null
 
@@ -231,19 +231,6 @@ perform_full_reset() {
         [ -f "$STATUS_DIR/${session_name}.status" ] && echo "done" > "$STATUS_DIR/${session_name}.status" 2>/dev/null
         [ -f "$STATUS_DIR/${session_name}-remote.status" ] && echo "done" > "$STATUS_DIR/${session_name}-remote.status" 2>/dev/null
         rm -f "$wait_file" 2>/dev/null
-    done
-
-    # Clear parked markers and normalize matching parked statuses back to done
-    for parked_file in "$PARKED_DIR"/*.parked; do
-        [ ! -f "$parked_file" ] && continue
-        session_name=$(basename "$parked_file" .parked)
-        if [ -f "$STATUS_DIR/${session_name}.status" ] && [ "$(cat "$STATUS_DIR/${session_name}.status" 2>/dev/null)" = "parked" ]; then
-            echo "done" > "$STATUS_DIR/${session_name}.status" 2>/dev/null
-        fi
-        if [ -f "$STATUS_DIR/${session_name}-remote.status" ] && [ "$(cat "$STATUS_DIR/${session_name}-remote.status" 2>/dev/null)" = "parked" ]; then
-            echo "done" > "$STATUS_DIR/${session_name}-remote.status" 2>/dev/null
-        fi
-        rm -f "$parked_file" 2>/dev/null
     done
 
     # Clear temp files
@@ -266,8 +253,12 @@ perform_full_reset() {
             continue
         fi
 
+        if [ -f "$PARKED_DIR/${session_name}.parked" ]; then
+            continue
+        fi
+
         status_value=$(cat "$status_file" 2>/dev/null)
-        if [ "$status_value" = "wait" ] || [ "$status_value" = "parked" ]; then
+        if [ "$status_value" = "wait" ]; then
             echo "done" > "$status_file" 2>/dev/null
         fi
 
@@ -296,13 +287,13 @@ fi
 sessions=$(get_sessions_with_status)
 
 # Add the reminder at the bottom of the session list
-sessions_with_reminder=$(echo -e "$(get_sessions_with_status)\n\n\033[1;36m Hit Ctrl-R to clear caches and reset everything! \033[0m")
+sessions_with_reminder=$(echo -e "$(get_sessions_with_status)\n\n\033[1;36m Hit Ctrl-R to clear stale caches and refresh! \033[0m")
 
 # Use fzf with manual refresh (Ctrl-R)
 selected=$(echo "$sessions_with_reminder" | fzf \
     --ansi \
     --no-sort \
-    --header="Sessions grouped by agent status | j/k: navigate | Enter: select | Esc: cancel | Ctrl-R: full reset" \
+    --header="Sessions grouped by agent status | j/k: navigate | Enter: select | Esc: cancel | Ctrl-R: clear stale caches" \
     --preview 'if echo {} | grep -q "━━━\|───"; then echo "Category separator"; else session=$(echo {} | awk "{print \$1}"); tmux capture-pane -pJ -t "$session" 2>/dev/null | cat -s || echo "No preview available"; fi' \
     --preview-window=right:40% \
     --prompt="Session> " \

--- a/tests/switcher-reset-preserves-parked.sh
+++ b/tests/switcher-reset-preserves-parked.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEST_HOME="$TMP_DIR/home"
+FAKE_BIN="$TMP_DIR/bin"
+STATUS_DIR="$TEST_HOME/.cache/tmux-agent-status"
+PARKED_DIR="$STATUS_DIR/parked"
+
+mkdir -p "$FAKE_BIN" "$STATUS_DIR" "$PARKED_DIR"
+
+cat > "$FAKE_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    list-sessions)
+        case "${2:-}" in
+            -F)
+                case "${3:-}" in
+                    "#{session_name}")
+                        echo "parked-task"
+                        ;;
+                    "#{session_name}:#{session_windows}:#{?session_attached,(attached),}")
+                        echo "parked-task:1:"
+                        ;;
+                    *)
+                        exit 1
+                        ;;
+                esac
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+    list-panes)
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+cat > "$FAKE_BIN/pgrep" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$FAKE_BIN/pgrep"
+
+cat > "$FAKE_BIN/pkill" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BIN/pkill"
+
+echo "parked" > "$STATUS_DIR/parked-task.status"
+: > "$PARKED_DIR/parked-task.parked"
+
+reset_output="$(PATH="$FAKE_BIN:$PATH" HOME="$TEST_HOME" "$REPO_DIR/scripts/hook-based-switcher.sh" --reset)"
+
+if ! printf '%s\n' "$reset_output" | grep -Fq "PARKED"; then
+    echo "Assertion failed: reset output should still include the PARKED section" >&2
+    exit 1
+fi
+if ! printf '%s\n' "$reset_output" | grep -Fq "[parked]"; then
+    echo "Assertion failed: parked sessions should remain parked after reset" >&2
+    exit 1
+fi
+if printf '%s\n' "$reset_output" | grep -Fq "[done]"; then
+    echo "Assertion failed: reset should not move parked sessions into done" >&2
+    exit 1
+fi
+if [ ! -f "$PARKED_DIR/parked-task.parked" ]; then
+    echo "Assertion failed: parked marker should survive reset" >&2
+    exit 1
+fi
+
+echo "switcher reset parked preservation regression checks passed"


### PR DESCRIPTION
## Summary
- keep parked markers and parked statuses intact when the switcher runs its Ctrl-R cache clear path
- continue clearing wait timers and stale cache files, but stop treating parked as resettable cache state
- tighten the switcher copy to describe Ctrl-R as clearing stale caches rather than resetting every session state

## Testing
- bash -n scripts/hook-based-switcher.sh tests/switcher-reset-preserves-parked.sh
- tests/switcher-reset-preserves-parked.sh
- tests/switcher-parked-group.sh
- tests/status-line-parked-summary.sh
- tests/parked-codex-reactivation.sh
- tests/status-line-wait-summary.sh
- tests/status-line-codex-regression.sh
- bash tests/nested-codex-detection.sh
- tests/smart-monitor-wait-expiry.sh