### PR TITLE
Extract fzf preview into dedicated script

### DIFF
--- a/scripts/hook-based-switcher.sh
+++ b/scripts/hook-based-switcher.sh
@@ -294,7 +294,7 @@ selected=$(echo "$sessions_with_reminder" | fzf \
     --ansi \
     --no-sort \
     --header="Sessions grouped by agent status | j/k: navigate | Enter: select | Esc: cancel | Ctrl-R: clear stale caches" \
-    --preview 'if echo {} | grep -q "━━━\|───"; then echo "Category separator"; else session=$(echo {} | awk "{print \$1}"); tmux capture-pane -pJ -t "$session" 2>/dev/null | cat -s || echo "No preview available"; fi' \
+    --preview "bash '$SCRIPT_DIR/preview-helper.sh' {}" \
     --preview-window=right:40% \
     --prompt="Session> " \
     --bind="j:down,k:up,ctrl-j:preview-down,ctrl-k:preview-up" \

--- a/scripts/preview-helper.sh
+++ b/scripts/preview-helper.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Preview helper for fzf session switcher.
+# Extracted from inline --preview to handle edge cases cleanly.
+# Inspired by mchowning/tmux-claude-status.
+
+input="$1"
+
+# Category separator lines
+if echo "$input" | grep -q "━━━\|───"; then
+    echo "Select a session below to see its preview"
+    exit 0
+fi
+
+# Ctrl-R reminder line
+if echo "$input" | grep -q "Hit Ctrl-R"; then
+    echo "Press Ctrl-R to refresh the session list"
+    exit 0
+fi
+
+# Empty lines
+if [ -z "$input" ] || [ "$input" = " " ]; then
+    exit 0
+fi
+
+# Extract session name and show pane content
+session=$(echo "$input" | awk '{print $1}')
+if [ -n "$session" ]; then
+    tmux capture-pane -pJ -t "$session" 2>/dev/null | cat -s || echo "No preview available"
+else
+    echo "No session selected"
+fi


### PR DESCRIPTION
## Summary
- Extracts the inline fzf `--preview` one-liner from the switcher into `scripts/preview-helper.sh`
- Properly handles separator lines, Ctrl-R reminder line, and empty lines
- Improves maintainability by removing fragile nested quoting from the fzf command

Inspired by @mchowning's fork ([mchowning/tmux-claude-status](https://github.com/mchowning/tmux-claude-status)).

## Test plan
- [x] All existing tests pass
- [ ] Open switcher and verify preview pane works for all session types

🤖 Generated with [Claude Code](https://claude.com/claude-code)