### PR TITLE
Add configurable popup/window display mode

### DIFF
--- a/scripts/window-wrapper.sh
+++ b/scripts/window-wrapper.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Wrapper for window-based session switching (alternative to popup).
+# Opens the switcher in a tmux window and cleans up after selection.
+# Inspired by ianchesal/tmux-claude-status.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/hook-based-switcher.sh"
+
+# If we're still in the switcher window, close it
+current_window=$(tmux display-message -p '#{window_name}')
+if [ "$current_window" = "agent-status" ]; then
+    tmux kill-window
+fi

--- a/tmux-agent-status.tmux
+++ b/tmux-agent-status.tmux
@@ -30,8 +30,20 @@ park_key=$(tmux show-option -gqv "@agent-park-key")
 [ -z "$wait_key" ] && wait_key="$default_wait_key"
 [ -z "$park_key" ] && park_key="$default_park_key"
 
+# Display method: "popup" (default, requires tmux 3.2+) or "window" (fallback)
+display_method=$(tmux show-option -gqv "@agent-status-display-method")
+[ -z "$display_method" ] && display_method=$(tmux show-option -gqv "@claude-status-display-method")
+[ -z "$display_method" ] && display_method="popup"
+
 # Set up custom session switcher with agent status (hook-based)
-tmux bind-key "$switcher_key" display-popup -E -w 80% -h 70% "$CURRENT_DIR/scripts/hook-based-switcher.sh"
+case "$display_method" in
+    "window")
+        tmux bind-key "$switcher_key" new-window -n "agent-status" "$CURRENT_DIR/scripts/window-wrapper.sh"
+        ;;
+    "popup"|*)
+        tmux bind-key "$switcher_key" display-popup -E -w 80% -h 70% "$CURRENT_DIR/scripts/hook-based-switcher.sh"
+        ;;
+esac
 
 # Set up keybinding to switch to next done project
 tmux bind-key "$next_done_key" run-shell "$CURRENT_DIR/scripts/next-done-project.sh"


### PR DESCRIPTION
## Summary
- Adds `@agent-status-display-method` option: `popup` (default) or `window`
- `popup` uses `display-popup` (requires tmux 3.2+) — the existing behavior
- `window` opens the switcher in a regular tmux window, for older tmux versions, SSH, or environments where popups don't work
- Adds `scripts/window-wrapper.sh` to handle window cleanup after selection

Inspired by @ianchesal's fork ([ianchesal/tmux-claude-status](https://github.com/ianchesal/tmux-claude-status)).

## Test plan
- [x] All existing tests pass
- [ ] Test default popup mode still works
- [ ] Test `set -g @agent-status-display-method 'window'` opens switcher in a window

🤖 Generated with [Claude Code](https://claude.com/claude-code)