### PR TITLE
Add ask status for AskUserQuestion

### DIFF
--- a/hooks/better-hook.sh
+++ b/hooks/better-hook.sh
@@ -44,18 +44,43 @@ if [ -n "$TMUX" ] || [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
         PARKED_FILE="$STATUS_DIR/parked/${TMUX_SESSION}.parked"
 
         case "$HOOK_TYPE" in
-            "UserPromptSubmit"|"PreToolUse")
-                # User submitted a prompt or Claude is calling a tool - cancel wait mode if active
+            "UserPromptSubmit")
+                # User submitted a prompt — explicit interaction, unpark and cancel wait
                 if [ -f "$WAIT_FILE" ]; then
-                    rm -f "$WAIT_FILE"  # Remove wait timer
+                    rm -f "$WAIT_FILE"
                 fi
                 if [ -f "$PARKED_FILE" ]; then
                     rm -f "$PARKED_FILE"
                 fi
                 echo "working" > "$STATUS_FILE"
-                # Only write to remote status file if we're in an SSH session
                 if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
                     echo "working" > "$REMOTE_STATUS_FILE" 2>/dev/null
+                fi
+                ;;
+            "PreToolUse")
+                # Agent is calling a tool — check if it's asking the user a question
+                TOOL_NAME=$(echo "$JSON_INPUT" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"tool_name"[[:space:]]*:[[:space:]]*"//;s/"//')
+                if [ -f "$WAIT_FILE" ]; then
+                    rm -f "$WAIT_FILE"
+                fi
+                if [ "$TOOL_NAME" = "AskUserQuestion" ]; then
+                    # Agent needs user input — distinct from "done" (agent stopped)
+                    if [ ! -f "$PARKED_FILE" ]; then
+                        echo "ask" > "$STATUS_FILE"
+                        if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
+                            echo "ask" > "$REMOTE_STATUS_FILE" 2>/dev/null
+                        fi
+                        SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+                        "$SCRIPT_DIR/../scripts/play-sound.sh" ask 2>/dev/null &
+                    fi
+                else
+                    # Normal tool use — mark working but don't unpark
+                    if [ ! -f "$PARKED_FILE" ]; then
+                        echo "working" > "$STATUS_FILE"
+                        if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
+                            echo "working" > "$REMOTE_STATUS_FILE" 2>/dev/null
+                        fi
+                    fi
                 fi
                 ;;
             "Stop")
@@ -67,11 +92,13 @@ if [ -n "$TMUX" ] || [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
                 fi
                 ;;
             "Notification")
-                # Claude is waiting for user input
-                echo "done" > "$STATUS_FILE"
-                # Only write to remote status file if we're in an SSH session
-                if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
-                    echo "done" > "$REMOTE_STATUS_FILE" 2>/dev/null
+                # Claude is waiting for user input — don't overwrite "ask" status
+                CURRENT_STATUS=$(cat "$STATUS_FILE" 2>/dev/null)
+                if [ "$CURRENT_STATUS" != "ask" ]; then
+                    echo "done" > "$STATUS_FILE"
+                    if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
+                        echo "done" > "$REMOTE_STATUS_FILE" 2>/dev/null
+                    fi
                 fi
 
                 # Play notification sound when Claude finishes

--- a/scripts/hook-based-switcher.sh
+++ b/scripts/hook-based-switcher.sh
@@ -83,6 +83,7 @@ get_agent_status() {
 # Get all sessions with formatted output
 get_sessions_with_status() {
     local working_sessions=()
+    local ask_sessions=()
     local done_sessions=()
     local wait_sessions=()
     local parked_sessions=()
@@ -127,6 +128,13 @@ get_sessions_with_status() {
                     formatted_line=$(printf "%-20s %2s windows %-12s [working]" "$name" "$windows" "$attached")
                 fi
                 working_sessions+=("$formatted_line")
+            elif [ "$agent_status" = "ask" ]; then
+                if [ -n "$ssh_indicator" ]; then
+                    formatted_line=$(printf "%-20s %2s windows %-12s %s [asking]" "$name" "$windows" "$attached" "$ssh_indicator")
+                else
+                    formatted_line=$(printf "%-20s %2s windows %-12s [asking]" "$name" "$windows" "$attached")
+                fi
+                ask_sessions+=("$formatted_line")
             elif [ "$agent_status" = "wait" ]; then
                 # Calculate remaining wait time
                 local wait_file="$STATUS_DIR/wait/${name}.wait"
@@ -179,30 +187,37 @@ get_sessions_with_status() {
         printf '%s\n' "${working_sessions[@]}"
     fi
 
+    # Asking sessions (agent needs user input)
+    if [ ${#ask_sessions[@]} -gt 0 ]; then
+        [ ${#working_sessions[@]} -gt 0 ] && echo
+        echo -e "\033[1;36m ASKING \033[0m"
+        printf '%s\n' "${ask_sessions[@]}"
+    fi
+
     # Done sessions
     if [ ${#done_sessions[@]} -gt 0 ]; then
-        [ ${#working_sessions[@]} -gt 0 ] && echo
+        [ ${#working_sessions[@]} -gt 0 ] || [ ${#ask_sessions[@]} -gt 0 ] && echo
         echo -e "\033[1;32m DONE \033[0m"
         printf '%s\n' "${done_sessions[@]}"
     fi
 
     # Wait sessions
     if [ ${#wait_sessions[@]} -gt 0 ]; then
-        [ ${#working_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] && echo
+        [ ${#working_sessions[@]} -gt 0 ] || [ ${#ask_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] && echo
         echo -e "\033[1;36m WAIT \033[0m"
         printf '%s\n' "${wait_sessions[@]}"
     fi
 
     # Parked sessions
     if [ ${#parked_sessions[@]} -gt 0 ]; then
-        [ ${#working_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] && echo
+        [ ${#working_sessions[@]} -gt 0 ] || [ ${#ask_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] && echo
         echo -e "\033[1;35m PARKED \033[0m"
         printf '%s\n' "${parked_sessions[@]}"
     fi
 
     # No agent sessions
     if [ ${#no_agent_sessions[@]} -gt 0 ]; then
-        [ ${#working_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] || [ ${#parked_sessions[@]} -gt 0 ] && echo
+        [ ${#working_sessions[@]} -gt 0 ] || [ ${#ask_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] || [ ${#parked_sessions[@]} -gt 0 ] && echo
         echo -e "\033[1;90m NO AGENT \033[0m"
         printf '%s\n' "${no_agent_sessions[@]}"
     fi

--- a/scripts/next-done-project.sh
+++ b/scripts/next-done-project.sh
@@ -90,7 +90,7 @@ while IFS=: read -r name windows attached; do
     if [ "$has_agent" = true ]; then
         [ -z "$agent_status" ] && agent_status="done"
 
-        if [ "$agent_status" = "done" ] && [ "$name" != "$exclude_session" ]; then
+        if { [ "$agent_status" = "done" ] || [ "$agent_status" = "ask" ]; } && [ "$name" != "$exclude_session" ]; then
             # Get completion time from status file modification time
             status_file=""
             if is_ssh_session "$name"; then

--- a/scripts/play-sound.sh
+++ b/scripts/play-sound.sh
@@ -3,7 +3,8 @@
 # Shared notification sound player for tmux-agent-status
 # Reads @agent-notification-sound from tmux options and plays the appropriate sound.
 # Falls back to @claude-notification-sound for backwards compatibility.
-# Usage: play-sound.sh [&]
+# Usage: play-sound.sh [sound_type] [&]
+#   sound_type: "ask" for agent-asking sound, omit for normal notification
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -13,9 +14,19 @@ PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 : "${DISPLAY:=:0}"
 export XDG_RUNTIME_DIR DISPLAY
 
-SOUND_CHOICE=$(tmux show-option -gqv @agent-notification-sound 2>/dev/null)
-[ -z "$SOUND_CHOICE" ] && SOUND_CHOICE=$(tmux show-option -gqv @claude-notification-sound 2>/dev/null)
-: "${SOUND_CHOICE:=chime}"
+SOUND_TYPE="${1:-notify}"
+
+# For "ask" events, use a distinct sound option (falls back to notification sound)
+if [ "$SOUND_TYPE" = "ask" ]; then
+    SOUND_CHOICE=$(tmux show-option -gqv @agent-ask-sound 2>/dev/null)
+    [ -z "$SOUND_CHOICE" ] && SOUND_CHOICE=$(tmux show-option -gqv @agent-notification-sound 2>/dev/null)
+    [ -z "$SOUND_CHOICE" ] && SOUND_CHOICE=$(tmux show-option -gqv @claude-notification-sound 2>/dev/null)
+    : "${SOUND_CHOICE:=bell}"
+else
+    SOUND_CHOICE=$(tmux show-option -gqv @agent-notification-sound 2>/dev/null)
+    [ -z "$SOUND_CHOICE" ] && SOUND_CHOICE=$(tmux show-option -gqv @claude-notification-sound 2>/dev/null)
+    : "${SOUND_CHOICE:=chime}"
+fi
 
 case "$SOUND_CHOICE" in
     none)

--- a/scripts/status-line.sh
+++ b/scripts/status-line.sh
@@ -135,6 +135,7 @@ check_agent_processes
 count_agent_status() {
     local working=0
     local waiting=0
+    local asking=0
     local done=0
     local total_agents=0
 
@@ -160,6 +161,7 @@ count_agent_status() {
                     "working") ((working++)); ((total_agents++)) ;;
                     "done") ((done++)); ((total_agents++)) ;;
                     "wait") ((waiting++)); ((total_agents++)) ;;
+                    "ask") ((asking++)); ((total_agents++)) ;;
                 esac
             fi
         elif [ -f "$remote_status_file" ] && ! is_ssh_session "$session"; then
@@ -186,12 +188,13 @@ count_agent_status() {
                     "working") ((working++)); ((total_agents++)) ;;
                     "done") ((done++)); ((total_agents++)) ;;
                     "wait") ((waiting++)); ((total_agents++)) ;;
+                    "ask") ((asking++)); ((total_agents++)) ;;
                 esac
             fi
         fi
     done < <(tmux list-sessions -F "#{session_name}" 2>/dev/null)
 
-    echo "$working:$waiting:$done:$total_agents"
+    echo "$working:$waiting:$asking:$done:$total_agents"
 }
 
 # Play notification sound
@@ -200,7 +203,7 @@ play_notification() {
 }
 
 # Get current status
-IFS=':' read -r working waiting done total_agents <<< "$(count_agent_status)"
+IFS=':' read -r working waiting asking done total_agents <<< "$(count_agent_status)"
 
 # Load previous status. Older versions stored only the working count; skip
 # notification diffing until we've written the new multi-count format once.
@@ -208,12 +211,12 @@ prev_done=""
 if [ -f "$LAST_STATUS_FILE" ]; then
     prev_status=$(cat "$LAST_STATUS_FILE" 2>/dev/null || echo "")
     if [[ "$prev_status" == *:* ]]; then
-        IFS=':' read -r _ _ prev_done <<< "$prev_status"
+        IFS=':' read -r _ _ _ prev_done <<< "$prev_status"
     fi
 fi
 
 # Save current status counts
-echo "$working:$waiting:$done" > "$LAST_STATUS_FILE"
+echo "$working:$waiting:$asking:$done" > "$LAST_STATUS_FILE"
 
 # Check if any agent just finished (done count increased)
 if [ -n "$prev_done" ] && [ "$done" -gt "$prev_done" ]; then
@@ -238,6 +241,15 @@ format_waiting_segment() {
     fi
 }
 
+format_asking_segment() {
+    local count="$1"
+    if [ "$count" -eq 1 ]; then
+        echo "#[fg=cyan,bold]? 1 asking#[default]"
+    else
+        echo "#[fg=cyan,bold]? $count asking#[default]"
+    fi
+}
+
 format_done_segment() {
     local count="$1"
     echo "#[fg=green]✓ $count done#[default]"
@@ -247,12 +259,13 @@ format_done_segment() {
 if [ "$total_agents" -eq 0 ]; then
     # No agent sessions
     echo ""
-elif [ "$working" -eq 0 ] && [ "$waiting" -eq 0 ] && [ "$done" -gt 0 ]; then
+elif [ "$working" -eq 0 ] && [ "$waiting" -eq 0 ] && [ "$asking" -eq 0 ] && [ "$done" -gt 0 ]; then
     # All agents are done
     echo "#[fg=green,bold]✓ All agents ready#[default]"
 else
     segments=()
     [ "$working" -gt 0 ] && segments+=("$(format_working_segment "$working")")
+    [ "$asking" -gt 0 ] && segments+=("$(format_asking_segment "$asking")")
     [ "$waiting" -gt 0 ] && segments+=("$(format_waiting_segment "$waiting")")
     [ "$done" -gt 0 ] && segments+=("$(format_done_segment "$done")")
     printf '%s\n' "${segments[*]}"


### PR DESCRIPTION
## Summary
- Parses `tool_name` from `PreToolUse` JSON stdin to detect `AskUserQuestion`
- New "ask" status means "agent needs your input" — distinct from working/done
- Status bar shows asking count in cyan (`? N asking`)
- Switcher shows ASKING group between WORKING and DONE
- Plays distinct sound (configurable via `@agent-ask-sound`, default: `bell`)
- `next-done-project` cycles through ask sessions too
- Notification handler won't overwrite ask with done
- Also splits `PreToolUse`/`UserPromptSubmit` in hook — only user prompts unpark

Inspired by @Moeay1's fork ([Moeay1/tmux-agent-status](https://github.com/Moeay1/tmux-agent-status)).

## Test plan
- [x] All existing tests pass
- [ ] Trigger AskUserQuestion and verify status shows "asking"
- [ ] Verify normal tool use still shows "working"
- [ ] Verify notification sound plays on ask

🤖 Generated with [Claude Code](https://claude.com/claude-code)