### PR TITLE
Add unread indicator for sessions that finish while away

### DIFF
--- a/hooks/better-hook.sh
+++ b/hooks/better-hook.sh
@@ -52,26 +52,31 @@ if [ -n "$TMUX" ] || [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
                 if [ -f "$PARKED_FILE" ]; then
                     rm -f "$PARKED_FILE"
                 fi
+                # Clear unread marker on user interaction
+                rm -f "$STATUS_DIR/${TMUX_SESSION}.unread" 2>/dev/null
                 echo "working" > "$STATUS_FILE"
                 # Only write to remote status file if we're in an SSH session
                 if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
+                    rm -f "$STATUS_DIR/${TMUX_SESSION}-remote.unread" 2>/dev/null
                     echo "working" > "$REMOTE_STATUS_FILE" 2>/dev/null
                 fi
                 ;;
-            "Stop")
-                # Claude has finished responding (SubagentStop excluded - subagents finishing doesn't mean the main agent is done)
+            "Stop"|"Notification")
+                # Agent finished — mark done and check if session is unread
+                PREV_STATUS=$(cat "$STATUS_FILE" 2>/dev/null || echo "")
                 echo "done" > "$STATUS_FILE"
-                # Only write to remote status file if we're in an SSH session
                 if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
                     echo "done" > "$REMOTE_STATUS_FILE" 2>/dev/null
                 fi
-                ;;
-            "Notification")
-                # Claude is waiting for user input
-                echo "done" > "$STATUS_FILE"
-                # Only write to remote status file if we're in an SSH session
-                if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
-                    echo "done" > "$REMOTE_STATUS_FILE" 2>/dev/null
+                # Mark unread if transitioning from working and session is not attached
+                if [ "$PREV_STATUS" = "working" ]; then
+                    IS_ATTACHED=$(tmux list-sessions -F "#{session_name}:#{?session_attached,1,}" 2>/dev/null | grep "^${TMUX_SESSION}:1$")
+                    if [ -z "$IS_ATTACHED" ]; then
+                        : > "$STATUS_DIR/${TMUX_SESSION}.unread"
+                        if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_TTY" ]; then
+                            : > "$STATUS_DIR/${TMUX_SESSION}-remote.unread"
+                        fi
+                    fi
                 fi
 
                 # Play notification sound when Claude finishes

--- a/scripts/hook-based-switcher.sh
+++ b/scripts/hook-based-switcher.sh
@@ -83,6 +83,7 @@ get_agent_status() {
 # Get all sessions with formatted output
 get_sessions_with_status() {
     local working_sessions=()
+    local unread_sessions=()
     local done_sessions=()
     local wait_sessions=()
     local parked_sessions=()
@@ -153,6 +154,13 @@ get_sessions_with_status() {
                     formatted_line=$(printf "%-20s %2s windows %-12s [parked]" "$name" "$windows" "$attached")
                 fi
                 parked_sessions+=("$formatted_line")
+            elif [ -f "$STATUS_DIR/${name}.unread" ] || [ -f "$STATUS_DIR/${name}-remote.unread" ]; then
+                if [ -n "$ssh_indicator" ]; then
+                    formatted_line=$(printf "%-20s %2s windows %-12s %s [unread]" "$name" "$windows" "$attached" "$ssh_indicator")
+                else
+                    formatted_line=$(printf "%-20s %2s windows %-12s [unread]" "$name" "$windows" "$attached")
+                fi
+                unread_sessions+=("$formatted_line")
             else
                 if [ -n "$ssh_indicator" ]; then
                     formatted_line=$(printf "%-20s %2s windows %-12s %s [done]" "$name" "$windows" "$attached" "$ssh_indicator")
@@ -179,30 +187,37 @@ get_sessions_with_status() {
         printf '%s\n' "${working_sessions[@]}"
     fi
 
+    # Unread sessions (finished while you were away)
+    if [ ${#unread_sessions[@]} -gt 0 ]; then
+        [ ${#working_sessions[@]} -gt 0 ] && echo
+        echo -e "\033[1;35m UNREAD \033[0m"
+        printf '%s\n' "${unread_sessions[@]}"
+    fi
+
     # Done sessions
     if [ ${#done_sessions[@]} -gt 0 ]; then
-        [ ${#working_sessions[@]} -gt 0 ] && echo
+        [ ${#working_sessions[@]} -gt 0 ] || [ ${#unread_sessions[@]} -gt 0 ] && echo
         echo -e "\033[1;32m DONE \033[0m"
         printf '%s\n' "${done_sessions[@]}"
     fi
 
     # Wait sessions
     if [ ${#wait_sessions[@]} -gt 0 ]; then
-        [ ${#working_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] && echo
+        [ ${#working_sessions[@]} -gt 0 ] || [ ${#unread_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] && echo
         echo -e "\033[1;36m WAIT \033[0m"
         printf '%s\n' "${wait_sessions[@]}"
     fi
 
     # Parked sessions
     if [ ${#parked_sessions[@]} -gt 0 ]; then
-        [ ${#working_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] && echo
+        [ ${#working_sessions[@]} -gt 0 ] || [ ${#unread_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] && echo
         echo -e "\033[1;35m PARKED \033[0m"
         printf '%s\n' "${parked_sessions[@]}"
     fi
 
     # No agent sessions
     if [ ${#no_agent_sessions[@]} -gt 0 ]; then
-        [ ${#working_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] || [ ${#parked_sessions[@]} -gt 0 ] && echo
+        [ ${#working_sessions[@]} -gt 0 ] || [ ${#unread_sessions[@]} -gt 0 ] || [ ${#done_sessions[@]} -gt 0 ] || [ ${#wait_sessions[@]} -gt 0 ] || [ ${#parked_sessions[@]} -gt 0 ] && echo
         echo -e "\033[1;90m NO AGENT \033[0m"
         printf '%s\n' "${no_agent_sessions[@]}"
     fi
@@ -305,5 +320,8 @@ selected=$(echo "$sessions_with_reminder" | fzf \
 # Switch to selected session (skip separator lines)
 if [ -n "$selected" ] && ! echo "$selected" | grep -q "━━━\|───"; then
     session_name=$(echo "$selected" | awk '{print $1}')
+    # Clear unread markers when switching to a session
+    rm -f "$STATUS_DIR/${session_name}.unread" 2>/dev/null
+    rm -f "$STATUS_DIR/${session_name}-remote.unread" 2>/dev/null
     tmux switch-client -t "$session_name"
 fi

--- a/scripts/status-line.sh
+++ b/scripts/status-line.sh
@@ -135,6 +135,7 @@ check_agent_processes
 count_agent_status() {
     local working=0
     local waiting=0
+    local unread=0
     local done=0
     local total_agents=0
 
@@ -158,7 +159,14 @@ count_agent_status() {
             if [ -n "$status" ]; then
                 case "$status" in
                     "working") ((working++)); ((total_agents++)) ;;
-                    "done") ((done++)); ((total_agents++)) ;;
+                    "done")
+                        if [ -f "$STATUS_DIR/${session}.unread" ] || [ -f "$STATUS_DIR/${session}-remote.unread" ]; then
+                            ((unread++))
+                        else
+                            ((done++))
+                        fi
+                        ((total_agents++))
+                        ;;
                     "wait") ((waiting++)); ((total_agents++)) ;;
                 esac
             fi
@@ -184,14 +192,21 @@ count_agent_status() {
             if [ -n "$status" ]; then
                 case "$status" in
                     "working") ((working++)); ((total_agents++)) ;;
-                    "done") ((done++)); ((total_agents++)) ;;
+                    "done")
+                        if [ -f "$STATUS_DIR/${session}.unread" ] || [ -f "$STATUS_DIR/${session}-remote.unread" ]; then
+                            ((unread++))
+                        else
+                            ((done++))
+                        fi
+                        ((total_agents++))
+                        ;;
                     "wait") ((waiting++)); ((total_agents++)) ;;
                 esac
             fi
         fi
     done < <(tmux list-sessions -F "#{session_name}" 2>/dev/null)
 
-    echo "$working:$waiting:$done:$total_agents"
+    echo "$working:$waiting:$unread:$done:$total_agents"
 }
 
 # Play notification sound
@@ -200,7 +215,7 @@ play_notification() {
 }
 
 # Get current status
-IFS=':' read -r working waiting done total_agents <<< "$(count_agent_status)"
+IFS=':' read -r working waiting unread done total_agents <<< "$(count_agent_status)"
 
 # Load previous status. Older versions stored only the working count; skip
 # notification diffing until we've written the new multi-count format once.
@@ -208,12 +223,12 @@ prev_done=""
 if [ -f "$LAST_STATUS_FILE" ]; then
     prev_status=$(cat "$LAST_STATUS_FILE" 2>/dev/null || echo "")
     if [[ "$prev_status" == *:* ]]; then
-        IFS=':' read -r _ _ prev_done <<< "$prev_status"
+        IFS=':' read -r _ _ _ prev_done <<< "$prev_status"
     fi
 fi
 
 # Save current status counts
-echo "$working:$waiting:$done" > "$LAST_STATUS_FILE"
+echo "$working:$waiting:$unread:$done" > "$LAST_STATUS_FILE"
 
 # Check if any agent just finished (done count increased)
 if [ -n "$prev_done" ] && [ "$done" -gt "$prev_done" ]; then
@@ -238,6 +253,15 @@ format_waiting_segment() {
     fi
 }
 
+format_unread_segment() {
+    local count="$1"
+    if [ "$count" -eq 1 ]; then
+        echo "#[fg=magenta,bold]! 1 unread#[default]"
+    else
+        echo "#[fg=magenta,bold]! $count unread#[default]"
+    fi
+}
+
 format_done_segment() {
     local count="$1"
     echo "#[fg=green]✓ $count done#[default]"
@@ -247,12 +271,13 @@ format_done_segment() {
 if [ "$total_agents" -eq 0 ]; then
     # No agent sessions
     echo ""
-elif [ "$working" -eq 0 ] && [ "$waiting" -eq 0 ] && [ "$done" -gt 0 ]; then
-    # All agents are done
+elif [ "$working" -eq 0 ] && [ "$waiting" -eq 0 ] && [ "$unread" -eq 0 ] && [ "$done" -gt 0 ]; then
+    # All agents are done (and read)
     echo "#[fg=green,bold]✓ All agents ready#[default]"
 else
     segments=()
     [ "$working" -gt 0 ] && segments+=("$(format_working_segment "$working")")
+    [ "$unread" -gt 0 ] && segments+=("$(format_unread_segment "$unread")")
     [ "$waiting" -gt 0 ] && segments+=("$(format_waiting_segment "$waiting")")
     [ "$done" -gt 0 ] && segments+=("$(format_done_segment "$done")")
     printf '%s\n' "${segments[*]}"


### PR DESCRIPTION
## Summary
- When an agent transitions working->done while user is on a different session, marks it "unread"
- Status bar shows unread count in magenta (`! N unread`)
- Switcher shows UNREAD group between WORKING and DONE
- Unread clears on: switcher selection, `UserPromptSubmit`, `PreToolUse`
- Only triggers on working->done transition when session is not attached

Inspired by @martin-meinke-ai's fork ([martin-meinke-ai/tmux-claude-status](https://github.com/martin-meinke-ai/tmux-claude-status), `feature/branch-and-unread-status` branch).

## Test plan
- [x] All existing tests pass
- [ ] Run agents in multiple sessions, verify unread appears when agent finishes while viewing another session
- [ ] Verify switching to unread session clears the marker
- [ ] Verify typing a prompt clears unread

🤖 Generated with [Claude Code](https://claude.com/claude-code)