### PR TITLE
[codex] Fix popup switcher action keys and close flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,20 @@ The status bar shows live activity:
 
 Parked sessions stay visible in the sidebar and switcher, but are excluded from the status-line summary.
 
-Inside the sidebar and popup switcher:
+Inside the popup switcher:
 
 - `Enter` switches to the selected session, window, or pane
-- `Tab` expands or collapses the selected session or window in the popup switcher
-- `x` closes the selected pane immediately
-- `x` on a window closes that window and all child panes after confirmation
-- `x` on a session closes that session and all child windows and panes after confirmation
+- `Tab` expands or collapses the selected session or window
+- `Ctrl-X` closes the selected pane immediately
+- `Ctrl-X` on a window closes that window and all child panes after confirmation
+- `Ctrl-X` on a session closes that session and all child windows and panes after confirmation
+- `Ctrl-P` parks or unparks the selected session, window, or pane
+- `Ctrl-W` opens wait mode for the selected target, or cancels an existing wait
+- `Ctrl-R` resets tracked state
+
+Inside the sidebar:
+
+- `x`, `p`, and `w` perform the same close, park, and wait actions without interfering with popup search input
 
 ## Configuration
 

--- a/scripts/hook-based-switcher.sh
+++ b/scripts/hook-based-switcher.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# fzf target switcher — hierarchical session/window/pane list with close support.
+# fzf target switcher — hierarchical session/window/pane list with management actions.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATUS_DIR="$HOME/.cache/tmux-agent-status"
@@ -276,6 +276,34 @@ perform_close() {
     fi
 }
 
+perform_popup_close() {
+    local sel_name="$1"
+    local sel_type="$2"
+
+    if selection_requires_confirmation "$sel_name" "$sel_type"; then
+        local prompt close_cmd confirm_cmd
+        prompt=$(selection_close_prompt "$sel_name" "$sel_type")
+        printf -v close_cmd '%q ' "$SCRIPT_DIR/close-target.sh" "$sel_name" "$sel_type"
+        printf -v confirm_cmd 'run-shell -b %q' "$close_cmd"
+        tmux confirm-before -b -p "$prompt" "$confirm_cmd"
+    else
+        dispatch_close_job "$sel_name" "$sel_type"
+    fi
+}
+
+emit_close_fzf_actions() {
+    local sel_name="$1"
+    local sel_type="$2"
+
+    if selection_requires_confirmation "$sel_name" "$sel_type"; then
+        printf 'execute-silent(bash %q --popup-close %q %q)+abort\n' \
+            "$0" "$sel_name" "$sel_type"
+    else
+        printf 'execute-silent(bash %q --state-dir %q --close %q %q)+reload(bash %q --state-dir %q --rows)\n' \
+            "$0" "$SWITCHER_STATE_DIR" "$sel_name" "$sel_type" "$0" "$SWITCHER_STATE_DIR"
+    fi
+}
+
 parse_args() {
     SWITCHER_COMMAND=""
     SWITCHER_ARG1=""
@@ -291,7 +319,7 @@ parse_args() {
                 SWITCHER_COMMAND="$1"
                 shift
                 ;;
-            --close|--toggle-expand)
+            --close|--popup-close|--toggle-expand|--close-fzf-actions)
                 SWITCHER_COMMAND="$1"
                 SWITCHER_ARG1="${2:-}"
                 SWITCHER_ARG2="${3:-}"
@@ -375,8 +403,16 @@ case "${SWITCHER_COMMAND:-}" in
         perform_close "$SWITCHER_ARG1" "$SWITCHER_ARG2"
         exit 0
         ;;
+    --popup-close)
+        perform_popup_close "$SWITCHER_ARG1" "$SWITCHER_ARG2"
+        exit 0
+        ;;
     --toggle-expand)
         toggle_expand "$SWITCHER_ARG1" "$SWITCHER_ARG2"
+        exit 0
+        ;;
+    --close-fzf-actions)
+        emit_close_fzf_actions "$SWITCHER_ARG1" "$SWITCHER_ARG2"
         exit 0
         ;;
     --reset)
@@ -403,12 +439,14 @@ selected=$(get_switcher_rows | fzf \
     --no-sort \
     --no-preview \
     --prompt="  " \
-    --header=$'\033[90mctrl-j/k scroll  tab expand/collapse  x close  ctrl-r reset\033[0m' \
+    --header=$'\033[90mctrl-j/k scroll  tab expand/collapse  ctrl-x close  ctrl-p park  ctrl-w wait  ctrl-r reset\033[0m' \
     --header-first \
     --bind="ctrl-j:down,ctrl-k:up" \
     --bind="tab:execute-silent(bash '$0' --state-dir '$state_dir' --toggle-expand {2} {1})+reload(bash '$0' --state-dir '$state_dir' --rows)" \
+    --bind="ctrl-p:execute-silent(bash '$SCRIPT_DIR/park-target.sh' {2} {1})+reload(bash '$0' --state-dir '$state_dir' --rows)" \
+    --bind="ctrl-w:execute-silent(bash '$SCRIPT_DIR/wait-target.sh' {2} {1})+abort" \
     --bind="ctrl-r:reload(bash '$0' --state-dir '$state_dir' --reset-rows)" \
-    --bind="x:execute-silent(bash '$0' --state-dir '$state_dir' --close {2} {1})+reload(bash '$0' --state-dir '$state_dir' --rows)" \
+    --bind="ctrl-x:transform(bash '$0' --state-dir '$state_dir' --close-fzf-actions {2} {1})" \
     --layout=reverse \
     --info=hidden \
     --no-separator \

--- a/scripts/park-target.sh
+++ b/scripts/park-target.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=lib/session-status.sh
+source "$SCRIPT_DIR/lib/session-status.sh"
+# shellcheck source=lib/selection-targets.sh
+source "$SCRIPT_DIR/lib/selection-targets.sh"
+
+force_status_dir_refresh() {
+    local tick_file="$STATUS_DIR/.park-target-refresh.$$"
+    : > "$tick_file"
+    rm -f "$tick_file"
+}
+
+write_session_state() {
+    local session="$1"
+    local state="$2"
+
+    if [ -f "$STATUS_DIR/${session}-remote.status" ]; then
+        echo "$state" > "$STATUS_DIR/${session}-remote.status"
+    else
+        echo "$state" > "$STATUS_DIR/${session}.status"
+    fi
+}
+
+selection_current_state() {
+    local sel_name="$1"
+    local sel_type="$2"
+    local scope session token
+
+    scope=$(selection_scope "$sel_name" "$sel_type") || return 1
+    session=$(selection_session "$sel_name" "$sel_type")
+    token=$(selection_token "$sel_name" "$sel_type")
+
+    case "$scope" in
+        session)
+            get_agent_status "$session"
+            ;;
+        window)
+            get_window_status "$session" "${token#w}"
+            ;;
+        pane)
+            get_pane_status "$session" "$token"
+            ;;
+    esac
+}
+
+toggle_park() {
+    local sel_name="$1"
+    local sel_type="$2"
+    local scope session token state
+
+    scope=$(selection_scope "$sel_name" "$sel_type")
+    session=$(selection_session "$sel_name" "$sel_type")
+    token=$(selection_token "$sel_name" "$sel_type")
+    state=$(selection_current_state "$sel_name" "$sel_type" || true)
+
+    mkdir -p "$PARKED_DIR" "$PANE_DIR"
+
+    case "$scope" in
+        session)
+            if [ "$state" = "parked" ]; then
+                rm -f "$PARKED_DIR/${session}.parked"
+                rm -f "$PARKED_DIR/${session}_"*.parked 2>/dev/null
+                write_session_state "$session" "done"
+
+                local pane_file=""
+                for pane_file in "$PANE_DIR/${session}_"*.status; do
+                    [ -f "$pane_file" ] || continue
+                    [ "$(cat "$pane_file" 2>/dev/null || echo "")" = "parked" ] && echo "done" > "$pane_file"
+                done
+            else
+                rm -f "$WAIT_DIR/${session}.wait"
+                : > "$PARKED_DIR/${session}.parked"
+                write_session_state "$session" "parked"
+
+                local pane_id=""
+                while IFS= read -r pane_id; do
+                    [ -n "$pane_id" ] || continue
+                    : > "$PARKED_DIR/${session}_${pane_id}.parked"
+                    echo "parked" > "$PANE_DIR/${session}_${pane_id}.status"
+                    rm -f "$WAIT_DIR/${session}_${pane_id}.wait" 2>/dev/null
+                done < <(tmux list-panes -t "$session" -F '#{pane_id}' 2>/dev/null)
+            fi
+            ;;
+        window)
+            local win_idx="${token#w}"
+            local pane_id="" pane_status_file=""
+
+            if [ "$state" = "parked" ]; then
+                while IFS= read -r pane_id; do
+                    [ -n "$pane_id" ] || continue
+                    rm -f "$PARKED_DIR/${session}_${pane_id}.parked"
+                    pane_status_file="$PANE_DIR/${session}_${pane_id}.status"
+                    [ -f "$pane_status_file" ] && [ "$(cat "$pane_status_file" 2>/dev/null || echo "")" = "parked" ] && echo "done" > "$pane_status_file"
+                done < <(tmux list-panes -t "${session}:${win_idx}" -F '#{pane_id}' 2>/dev/null)
+
+                rm -f "$PARKED_DIR/${session}.parked"
+                [ "$(get_agent_status "$session")" = "parked" ] && write_session_state "$session" "done"
+            else
+                while IFS= read -r pane_id; do
+                    [ -n "$pane_id" ] || continue
+                    : > "$PARKED_DIR/${session}_${pane_id}.parked"
+                    echo "parked" > "$PANE_DIR/${session}_${pane_id}.status"
+                    rm -f "$WAIT_DIR/${session}_${pane_id}.wait" 2>/dev/null
+                done < <(tmux list-panes -t "${session}:${win_idx}" -F '#{pane_id}' 2>/dev/null)
+            fi
+            ;;
+        pane)
+            if [ "$state" = "parked" ]; then
+                rm -f "$PARKED_DIR/${session}_${token}.parked"
+                if [ -f "$PANE_DIR/${session}_${token}.status" ]; then
+                    echo "done" > "$PANE_DIR/${session}_${token}.status"
+                fi
+
+                rm -f "$PARKED_DIR/${session}.parked"
+                [ "$(get_agent_status "$session")" = "parked" ] && write_session_state "$session" "done"
+            else
+                rm -f "$WAIT_DIR/${session}_${token}.wait" 2>/dev/null
+                : > "$PARKED_DIR/${session}_${token}.parked"
+                echo "parked" > "$PANE_DIR/${session}_${token}.status"
+            fi
+            ;;
+    esac
+
+    force_status_dir_refresh
+}
+
+toggle_park "$1" "$2"

--- a/scripts/wait-target.sh
+++ b/scripts/wait-target.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=lib/session-status.sh
+source "$SCRIPT_DIR/lib/session-status.sh"
+# shellcheck source=lib/selection-targets.sh
+source "$SCRIPT_DIR/lib/selection-targets.sh"
+
+force_status_dir_refresh() {
+    local tick_file="$STATUS_DIR/.wait-target-refresh.$$"
+    : > "$tick_file"
+    rm -f "$tick_file"
+}
+
+write_session_state() {
+    local session="$1"
+    local state="$2"
+
+    if [ -f "$STATUS_DIR/${session}-remote.status" ]; then
+        echo "$state" > "$STATUS_DIR/${session}-remote.status"
+    else
+        echo "$state" > "$STATUS_DIR/${session}.status"
+    fi
+}
+
+selection_current_state() {
+    local sel_name="$1"
+    local sel_type="$2"
+    local scope session token
+
+    scope=$(selection_scope "$sel_name" "$sel_type") || return 1
+    session=$(selection_session "$sel_name" "$sel_type")
+    token=$(selection_token "$sel_name" "$sel_type")
+
+    case "$scope" in
+        session)
+            get_agent_status "$session"
+            ;;
+        window)
+            get_window_status "$session" "${token#w}"
+            ;;
+        pane)
+            get_pane_status "$session" "$token"
+            ;;
+    esac
+}
+
+cancel_wait() {
+    local sel_name="$1"
+    local sel_type="$2"
+    local scope session token
+
+    scope=$(selection_scope "$sel_name" "$sel_type")
+    session=$(selection_session "$sel_name" "$sel_type")
+    token=$(selection_token "$sel_name" "$sel_type")
+
+    case "$scope" in
+        session)
+            rm -f "$WAIT_DIR/${session}.wait"
+            rm -f "$WAIT_DIR/${session}_"*.wait 2>/dev/null
+            write_session_state "$session" "done"
+
+            local pane_file=""
+            for pane_file in "$PANE_DIR/${session}_"*.status; do
+                [ -f "$pane_file" ] || continue
+                [ "$(cat "$pane_file" 2>/dev/null || echo "")" = "wait" ] && echo "done" > "$pane_file"
+            done
+            ;;
+        window)
+            local win_idx="${token#w}"
+            local pane_id="" pane_status_file=""
+
+            while IFS= read -r pane_id; do
+                [ -n "$pane_id" ] || continue
+                rm -f "$WAIT_DIR/${session}_${pane_id}.wait"
+                pane_status_file="$PANE_DIR/${session}_${pane_id}.status"
+                [ -f "$pane_status_file" ] && [ "$(cat "$pane_status_file" 2>/dev/null || echo "")" = "wait" ] && echo "done" > "$pane_status_file"
+            done < <(tmux list-panes -t "${session}:${win_idx}" -F '#{pane_id}' 2>/dev/null)
+
+            local remaining_wait=""
+            remaining_wait=$(find "$WAIT_DIR" -maxdepth 1 -type f -name "${session}_*.wait" -print -quit 2>/dev/null || true)
+            if [ -z "$remaining_wait" ]; then
+                rm -f "$WAIT_DIR/${session}.wait"
+                write_session_state "$session" "done"
+            fi
+            ;;
+        pane)
+            rm -f "$WAIT_DIR/${session}_${token}.wait"
+            if [ -f "$PANE_DIR/${session}_${token}.status" ] && [ "$(cat "$PANE_DIR/${session}_${token}.status" 2>/dev/null || echo "")" = "wait" ]; then
+                echo "done" > "$PANE_DIR/${session}_${token}.status"
+            fi
+
+            local remaining_wait=""
+            remaining_wait=$(find "$WAIT_DIR" -maxdepth 1 -type f -name "${session}_*.wait" -print -quit 2>/dev/null || true)
+            if [ -z "$remaining_wait" ]; then
+                rm -f "$WAIT_DIR/${session}.wait"
+                write_session_state "$session" "done"
+            fi
+            ;;
+    esac
+
+    force_status_dir_refresh
+}
+
+prompt_wait() {
+    local sel_name="$1"
+    local target_template="${sel_name//%/%%}"
+
+    tmux command-prompt -p "Wait time in minutes:" \
+        "run-shell '$SCRIPT_DIR/wait-session-handler.sh \"$target_template\" %1'"
+}
+
+main() {
+    local sel_name="$1"
+    local sel_type="$2"
+    local state=""
+
+    state=$(selection_current_state "$sel_name" "$sel_type" || true)
+    if [ "$state" = "wait" ]; then
+        cancel_wait "$sel_name" "$sel_type"
+    else
+        prompt_wait "$sel_name"
+    fi
+}
+
+main "$1" "$2"

--- a/tests/park-target-window.sh
+++ b/tests/park-target-window.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEST_HOME="$TMP_DIR/home"
+FAKE_BIN="$TMP_DIR/bin"
+STATUS_DIR="$TEST_HOME/.cache/tmux-agent-status"
+PANE_DIR="$STATUS_DIR/panes"
+WAIT_DIR="$STATUS_DIR/wait"
+PARKED_DIR="$STATUS_DIR/parked"
+
+mkdir -p "$FAKE_BIN" "$PANE_DIR" "$WAIT_DIR" "$PARKED_DIR"
+
+cat > "$FAKE_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    list-panes)
+        if [ "${2:-}" = "-t" ] && [ "${3:-}" = "repo:0" ] && [ "${4:-}" = "-F" ] && [ "${5:-}" = "#{pane_id}" ]; then
+            printf '%%1\n%%2\n'
+            exit 0
+        fi
+        exit 1
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+echo "done" > "$PANE_DIR/repo_%1.status"
+echo "working" > "$PANE_DIR/repo_%2.status"
+echo "1" > "$WAIT_DIR/repo_%1.wait"
+
+PATH="$FAKE_BIN:$PATH" \
+HOME="$TEST_HOME" \
+bash "$REPO_DIR/scripts/park-target.sh" "repo:w0" "P"
+
+if [ ! -f "$PARKED_DIR/repo_%1.parked" ] || [ ! -f "$PARKED_DIR/repo_%2.parked" ]; then
+    echo "Assertion failed: parking a window should create parked markers for child panes" >&2
+    exit 1
+fi
+if [ "$(cat "$PANE_DIR/repo_%1.status")" != "parked" ] || [ "$(cat "$PANE_DIR/repo_%2.status")" != "parked" ]; then
+    echo "Assertion failed: parking a window should mark child pane statuses as parked" >&2
+    exit 1
+fi
+if [ -f "$WAIT_DIR/repo_%1.wait" ]; then
+    echo "Assertion failed: parking a window should clear pane wait files in that window" >&2
+    exit 1
+fi
+
+PATH="$FAKE_BIN:$PATH" \
+HOME="$TEST_HOME" \
+bash "$REPO_DIR/scripts/park-target.sh" "repo:w0" "P"
+
+if [ -f "$PARKED_DIR/repo_%1.parked" ] || [ -f "$PARKED_DIR/repo_%2.parked" ]; then
+    echo "Assertion failed: toggling the same window should unpark its child panes" >&2
+    exit 1
+fi
+
+echo "park target window regression checks passed"

--- a/tests/switcher-action-bindings.sh
+++ b/tests/switcher-action-bindings.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_FILE="$REPO_DIR/scripts/hook-based-switcher.sh"
+
+assert_contains() {
+    local needle="$1"
+    local message="$2"
+
+    if ! grep -Fq -- "$needle" "$SCRIPT_FILE"; then
+        echo "Assertion failed: $message" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1"
+    local message="$2"
+
+    if grep -Fq -- "$needle" "$SCRIPT_FILE"; then
+        echo "Assertion failed: $message" >&2
+        exit 1
+    fi
+}
+
+assert_contains '--bind="ctrl-x:' "switcher should use ctrl-x for close"
+assert_contains '--bind="ctrl-p:' "switcher should use ctrl-p for park"
+assert_contains '--bind="ctrl-w:' "switcher should use ctrl-w for wait"
+assert_contains 'ctrl-x close  ctrl-p park  ctrl-w wait' "switcher header should advertise control-key actions"
+
+assert_not_contains '--bind="x:' "plain x should not be bound in the switcher"
+assert_not_contains '--bind="p:' "plain p should not be bound in the switcher"
+assert_not_contains '--bind="w:' "plain w should not be bound in the switcher"
+assert_not_contains '--bind="alt-x:' "alt-x should no longer be bound in the switcher"
+
+echo "switcher action binding regression checks passed"

--- a/tests/switcher-close-actions.sh
+++ b/tests/switcher-close-actions.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+STATE_DIR="$TMP_DIR/state"
+mkdir -p "$STATE_DIR"
+
+window_actions="$("$REPO_DIR/scripts/hook-based-switcher.sh" --state-dir "$STATE_DIR" --close-fzf-actions "repo:w0" "P")"
+pane_actions="$("$REPO_DIR/scripts/hook-based-switcher.sh" --state-dir "$STATE_DIR" --close-fzf-actions "repo:%1" "P")"
+
+if [[ "$window_actions" != *"--popup-close repo:w0 P"* ]] || [[ "$window_actions" != *"+abort"* ]]; then
+    echo "Assertion failed: window close actions should abort fzf and route through popup-close" >&2
+    echo "$window_actions" >&2
+    exit 1
+fi
+
+if [[ "$pane_actions" != *"--close repo:%1 P"* ]] || [[ "$pane_actions" != *"+reload("* ]]; then
+    echo "Assertion failed: pane close actions should reload the list in place" >&2
+    echo "$pane_actions" >&2
+    exit 1
+fi
+
+echo "switcher close action regression checks passed"

--- a/tests/switcher-popup-close-confirmation.sh
+++ b/tests/switcher-popup-close-confirmation.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/bin"
+LOG_FILE="$TMP_DIR/tmux.log"
+mkdir -p "$FAKE_BIN"
+
+cat > "$FAKE_BIN/tmux" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "\$*" >> "$LOG_FILE"
+
+case "\${1:-}" in
+    display-message)
+        if [ "\${2:-}" = "-p" ] && [ "\${3:-}" = "-t" ] && [ "\${4:-}" = "repo:0" ] && [ "\${5:-}" = "#{window_name}" ]; then
+            echo "build"
+            exit 0
+        fi
+        exit 1
+        ;;
+    confirm-before)
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+PATH="$FAKE_BIN:$PATH" \
+HOME="$TMP_DIR/home" \
+"$REPO_DIR/scripts/hook-based-switcher.sh" --popup-close "repo:w0" "P"
+
+if ! grep -Fq "confirm-before -b -p Close window repo:0 (build) and all child panes?" "$LOG_FILE"; then
+    echo "Assertion failed: popup close should request background confirmation for window targets" >&2
+    cat "$LOG_FILE" >&2
+    exit 1
+fi
+
+echo "switcher popup close confirmation regression checks passed"

--- a/tests/wait-target-prompt.sh
+++ b/tests/wait-target-prompt.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEST_HOME="$TMP_DIR/home"
+FAKE_BIN="$TMP_DIR/bin"
+STATUS_DIR="$TEST_HOME/.cache/tmux-agent-status"
+PANE_DIR="$STATUS_DIR/panes"
+LOG_FILE="$TMP_DIR/tmux.log"
+
+mkdir -p "$FAKE_BIN" "$PANE_DIR"
+
+cat > "$FAKE_BIN/tmux" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "\$*" >> "$LOG_FILE"
+
+case "\${1:-}" in
+    command-prompt)
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+echo "working" > "$PANE_DIR/repo_%1.status"
+
+PATH="$FAKE_BIN:$PATH" \
+HOME="$TEST_HOME" \
+bash "$REPO_DIR/scripts/wait-target.sh" "repo:%1" "P"
+
+if ! grep -Fq "command-prompt -p Wait time in minutes:" "$LOG_FILE"; then
+    echo "Assertion failed: wait target should open a tmux command prompt" >&2
+    exit 1
+fi
+if ! grep -Fq 'repo:%%1' "$LOG_FILE"; then
+    echo "Assertion failed: wait target should escape pane percent signs in the prompt command" >&2
+    cat "$LOG_FILE" >&2
+    exit 1
+fi
+
+echo "wait target prompt regression checks passed"


### PR DESCRIPTION
## Summary
- move popup switcher management actions off printable keys and onto control-key bindings
- add popup park and wait target helpers so fuzzy search input is no longer intercepted
- fix window and session close from the popup by aborting fzf before handing confirmation back to tmux

## Validation
- `bash -n scripts/hook-based-switcher.sh scripts/park-target.sh scripts/wait-target.sh`
- `bash tests/switcher-action-bindings.sh`
- `bash tests/switcher-close-actions.sh`
- `bash tests/switcher-popup-close-confirmation.sh`
- `bash tests/park-target-window.sh`
- `bash tests/wait-target-prompt.sh`
- `bash tests/switcher-close-confirmation.sh`
- `bash tests/switcher-scope-list.sh`
- `bash tests/switcher-reset-preserves-parked.sh`
- `bash tests/switcher-parked-group.sh`
