### PR TITLE
[codex] Update Codex hooks feature flag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ Enable hooks in `~/.codex/config.toml`:
 
 ```toml
 [features]
-codex_hooks = true
+hooks = true
 ```
+
+For a one-off session, you can also start Codex with `codex --enable hooks`.
 
 To enable Codex tracking globally, add `~/.codex/hooks.json`:
 

--- a/tests/readme-codex-feature-flag.sh
+++ b/tests/readme-codex-feature-flag.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+README="$REPO_DIR/README.md"
+deprecated_flag="codex""_hooks"
+
+if grep -q "$deprecated_flag" "$README"; then
+    echo "README should not document the deprecated Codex hooks feature flag" >&2
+    exit 1
+fi
+
+grep -q 'hooks = true' "$README"
+grep -q 'codex --enable hooks' "$README"


### PR DESCRIPTION
## Summary

Update the Codex CLI setup instructions to use the current hooks feature flag name, `hooks`, instead of the deprecated `codex_hooks` key.

Also document the equivalent one-off CLI flag, `codex --enable hooks`, and add a small README regression test so the deprecated flag does not get reintroduced.

## Root Cause

The plugin docs still told users to add `[features].codex_hooks = true` to `~/.codex/config.toml`. Current Codex CLI releases warn that `[features].codex_hooks` is deprecated and should be replaced by `[features].hooks` or `--enable hooks`.

## Validation

- `bash tests/readme-codex-feature-flag.sh`
- `for test_script in tests/*.sh; do bash "$test_script"; done`
