### PR TITLE
[codex] Clarify Codex hook trust setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,11 @@ To enable Codex tracking globally, add `~/.codex/hooks.json`:
 }
 ```
 
+Restart Codex, then run `/hooks` in the CLI and trust the new command hooks if Codex marks them as pending review. Non-managed command hooks must be trusted before Codex will run them.
+
 Codex state is also hook-based. The handler marks the tmux session or pane `working` on `UserPromptSubmit` and `PreToolUse`, resets it to `done` on `Stop`, and seeds resumed sessions on `SessionStart`.
 
-This repo also ships a repo-local [`.codex/hooks.json`](.codex/hooks.json), so Codex can pick up the same hook handler automatically when you work inside `tmux-agent-status` itself.
+For repo-local tracking while working on this plugin, put the same hook shape in `<repo>/.codex/hooks.json`. Codex loads project-local hooks once the project `.codex/` layer is trusted.
 
 ## Custom Agent Integration
 

--- a/hooks/codex-hook.sh
+++ b/hooks/codex-hook.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Codex hook for tmux-agent-status.
-# Hook events are passed as the first argument from hooks.json; the JSON payload
-# is read from stdin and ignored here because tmux-agent-status only needs the
-# event name to update session state.
+# Hook events are passed as the first argument by the configured Codex command
+# hook. The JSON payload is read from stdin and ignored here because
+# tmux-agent-status only needs the event name to update session state.
 
 STATUS_DIR="$HOME/.cache/tmux-agent-status"
 WAIT_DIR="$STATUS_DIR/wait"


### PR DESCRIPTION
## Summary

Clarifies the Codex hook setup docs after the hook feature flag update landed in #31.

- Documents the `/hooks` trust step required before Codex runs non-managed command hooks.
- Rewords the repo-local hook note so it does not point at an untracked `.codex/hooks.json` file.
- Updates the Codex hook script comment so it refers to the configured command hook rather than only `hooks.json`.

## Why

The setup can appear broken after updating the hook config if Codex has not trusted the command hooks yet. The README now calls out that required review step explicitly.

## Validation

- `bash tests/readme-codex-feature-flag.sh`
- `bash tests/codex-hook-lifecycle.sh`
- `bash tests/status-line-codex-regression.sh`
- `bash -n hooks/codex-hook.sh`
