### PR TITLE
[codex] Fix macOS Bash 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ set -g @plugin 'samleeney/tmux-agent-status'
 
 Then press `prefix + I` to install.
 
+On macOS, install a modern Bash before using the sidebar:
+
+```bash
+brew install bash
+```
+
+The plugin auto-detects Homebrew Bash at `/opt/homebrew/bin/bash` or `/usr/local/bin/bash` when macOS launches scripts with the system Bash 3.2.
+If Bash is installed somewhere else, set `TMUX_AGENT_STATUS_BASH` to that path.
+
 By default the plugin:
 
 - Appends the live summary to `status-right`

--- a/scripts/lib/require-bash4.sh
+++ b/scripts/lib/require-bash4.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# tmux-agent-status uses associative arrays in its shared collection code.
+# macOS still ships Bash 3.2 as /bin/bash, so re-exec plugin entrypoints with a
+# modern Bash when one is available from Homebrew or other common package paths.
+
+[[ -n "${_TMUX_AGENT_STATUS_REQUIRE_BASH4_LOADED:-}" ]] && return 0
+_TMUX_AGENT_STATUS_REQUIRE_BASH4_LOADED=1
+
+_tmux_agent_status_bash4_is_current() {
+    [ -n "${BASH_VERSINFO:-}" ] && [ "${BASH_VERSINFO[0]}" -ge 4 ] 2>/dev/null
+}
+
+_tmux_agent_status_bash4_candidate_ok() {
+    local candidate="$1"
+    [ -n "$candidate" ] || return 1
+    [ -x "$candidate" ] || return 1
+    "$candidate" -c '[ "${BASH_VERSINFO[0]}" -ge 4 ]' >/dev/null 2>&1
+}
+
+_tmux_agent_status_find_bash4() {
+    local candidate=""
+    local seen=":"
+
+    for candidate in \
+        "${TMUX_AGENT_STATUS_BASH:-}" \
+        "$(command -v bash 2>/dev/null || true)" \
+        /opt/homebrew/bin/bash \
+        /usr/local/bin/bash \
+        /opt/local/bin/bash \
+        /sw/bin/bash
+    do
+        [ -n "$candidate" ] || continue
+        case "$seen" in
+            *":$candidate:"*) continue ;;
+        esac
+        seen="${seen}${candidate}:"
+
+        if _tmux_agent_status_bash4_candidate_ok "$candidate"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+_tmux_agent_status_abs_path() {
+    local path="$1"
+    local dir=""
+    local base=""
+
+    case "$path" in
+        /*)
+            printf '%s\n' "$path"
+            ;;
+        */*)
+            dir="$(cd "$(dirname "$path")" && pwd)" || return 1
+            base="$(basename "$path")"
+            printf '%s/%s\n' "$dir" "$base"
+            ;;
+        *)
+            command -v -- "$path"
+            ;;
+    esac
+}
+
+require_bash4() {
+    _tmux_agent_status_bash4_is_current && return 0
+
+    local bash4=""
+    bash4="$(_tmux_agent_status_find_bash4)" || {
+        cat >&2 <<'EOF'
+tmux-agent-status requires Bash 4 or newer.
+macOS /bin/bash is Bash 3.2; install a newer Bash, for example:
+  brew install bash
+EOF
+        exit 1
+    }
+
+    local stack_depth="${#BASH_SOURCE[@]}"
+    if [ "$stack_depth" -lt 3 ]; then
+        echo "tmux-agent-status: rerun this command with Bash 4 or newer: $bash4" >&2
+        exit 1
+    fi
+
+    local script_index=$((stack_depth - 1))
+    local script_path="${BASH_SOURCE[$script_index]}"
+    script_path="$(_tmux_agent_status_abs_path "$script_path")" || {
+        echo "tmux-agent-status: found Bash 4 at $bash4, but could not resolve the script path" >&2
+        exit 1
+    }
+
+    exec "$bash4" "$script_path" "$@"
+}

--- a/scripts/lib/session-status.sh
+++ b/scripts/lib/session-status.sh
@@ -6,6 +6,11 @@
 #           get_window_status, get_agent_status, sync_session_after_child_scope_change,
 #           plus STATUS_DIR / PARKED_DIR / WAIT_DIR constants.
 
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=require-bash4.sh
+source "$_LIB_DIR/require-bash4.sh"
+require_bash4 "$@"
+
 [[ -n "${_SESSION_STATUS_LOADED:-}" ]] && return 0
 _SESSION_STATUS_LOADED=1
 
@@ -21,7 +26,6 @@ mkdir -p "$STATUS_DIR" "$PARKED_DIR" "$WAIT_DIR" "$PANE_DIR" "$SIDEBAR_CLIENT_DI
 [ -f "$REFRESH_FILE" ] || : > "$REFRESH_FILE"
 
 # Source process-detection helpers from the same lib directory.
-_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=agent-processes.sh
 source "$_LIB_DIR/agent-processes.sh"
 

--- a/tests/require-bash4-helper.sh
+++ b/tests/require-bash4-helper.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+source "$REPO_DIR/scripts/lib/require-bash4.sh"
+
+require_bash4
+
+bash4="$(_tmux_agent_status_find_bash4)"
+[ -n "$bash4" ] || {
+    echo "Expected to find a Bash 4+ executable" >&2
+    exit 1
+}
+
+"$bash4" -c '[ "${BASH_VERSINFO[0]}" -ge 4 ]'
+
+echo "Bash 4 requirement helper checks passed"


### PR DESCRIPTION
## Summary

Fixes #32.

- Adds a shared Bash 4+ requirement helper that re-execs tmux-agent-status entrypoints with a modern Bash when macOS starts them under `/bin/bash` 3.2.
- Detects common Homebrew, MacPorts, and Fink Bash paths, with `TMUX_AGENT_STATUS_BASH` as an explicit override.
- Wires the helper into `session-status.sh`, which is sourced before the reported associative-array failures.
- Documents the macOS `brew install bash` prerequisite and adds a focused helper test.

## Why

macOS ships Bash 3.2, which does not support `declare -A` or `local -A`. The sidebar/status scripts use associative arrays in shared collection code, so they need to run under Bash 4 or newer instead of failing when launched from tmux on macOS.

## Validation

- `for f in $(rg --files scripts hooks tests | sort); do bash -n "$f"; done`
- `for t in tests/*.sh; do bash "$t"; done`
- `TMUX_AGENT_STATUS_BASH="$(command -v bash)" bash tests/require-bash4-helper.sh`
- `./scripts/sidebar-signal.sh refresh; echo exit:$?`
