### PR TITLE
Keep agent "working" while a background task is still running

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Add hooks to `~/.claude/settings.json`:
 }
 ```
 
-Claude Code state is tracked entirely through hooks, so the plugin gets precise working/done transitions directly from the agent.
+Claude Code state is tracked entirely through hooks, so the plugin gets precise working/done transitions directly from the agent. If a turn ends while a background task is still running (e.g. a `run_in_background` Bash command), the `Stop` payload's `background_tasks` array keeps the session marked `working` until a later `Stop` reports the task finished — so backgrounded work doesn't show a premature green checkmark.
 
 ## Codex CLI Setup
 

--- a/hooks/better-hook.sh
+++ b/hooks/better-hook.sh
@@ -11,8 +11,9 @@ REFRESH_FILE="$STATUS_DIR/.sidebar-refresh"
 mkdir -p "$STATUS_DIR" "$WAIT_DIR" "$PARKED_DIR" "$PANE_DIR"
 [ -f "$REFRESH_FILE" ] || : > "$REFRESH_FILE"
 
-# Drain JSON from stdin (required by Claude Code hooks).
-cat >/dev/null 2>&1 || true
+# Read JSON from stdin (required by Claude Code hooks). The Stop payload
+# carries a `background_tasks` array that we inspect below.
+HOOK_JSON="$(cat 2>/dev/null || true)"
 
 in_remote_session() {
     [ -n "${SSH_CONNECTION:-}" ] || [ -n "${SSH_TTY:-}" ]
@@ -107,6 +108,37 @@ mark_refresh() {
     touch "$REFRESH_FILE" 2>/dev/null || true
 }
 
+# Returns 0 if the Claude Code Stop payload reports a background task that is
+# still running (e.g. a `run_in_background` Bash command). When the agent ends
+# its turn while a background task keeps working, it isn't really idle, so we
+# keep it "working" instead of flipping to "done". Claude re-invokes the agent
+# when the task finishes, firing another Stop with an empty (or all-finished)
+# background_tasks array, which then marks the session done.
+#
+# Older Claude versions omit the field entirely; that yields no match and the
+# Stop is treated as done, matching the previous behaviour.
+has_running_background_task() {
+    local json="$1"
+    [ -n "$json" ] || return 1
+
+    if command -v jq >/dev/null 2>&1; then
+        local count
+        count="$(printf '%s' "$json" | \
+            jq -r '[.background_tasks[]? | select(.status == "running")] | length' \
+            2>/dev/null)"
+        [ -n "$count" ] && [ "$count" -gt 0 ] 2>/dev/null
+        return
+    fi
+
+    # Fallback without jq: an empty array is "background_tasks":[] and is
+    # rejected first; otherwise look for a running task in a populated array.
+    case "$json" in
+        *'"background_tasks":[]'*) return 1 ;;
+        *'"background_tasks":['*'"status":"running"'*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 TMUX_SESSION=$(get_tmux_session) || exit 0
 HOOK_TYPE="${1:-}"
 WAIT_FILE="$WAIT_DIR/${TMUX_SESSION}.wait"
@@ -132,8 +164,14 @@ case "$HOOK_TYPE" in
         ;;
     Stop)
         # Claude has finished responding (SubagentStop excluded - subagents
-        # finishing doesn't mean the main agent is done).
-        set_status "$TMUX_SESSION" "done"
+        # finishing doesn't mean the main agent is done). If the turn ended
+        # while a background task is still running, the agent isn't idle yet —
+        # keep it working until a later Stop reports the task finished.
+        if has_running_background_task "$HOOK_JSON"; then
+            set_status "$TMUX_SESSION" "working"
+        else
+            set_status "$TMUX_SESSION" "done"
+        fi
         mark_refresh
         ;;
     Notification)

--- a/tests/claude-hook-background-task.sh
+++ b/tests/claude-hook-background-task.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEST_HOME="$TMP_DIR/home"
+FAKE_BIN="$TMP_DIR/bin"
+STATUS_DIR="$TEST_HOME/.cache/tmux-agent-status"
+PANE_DIR="$STATUS_DIR/panes"
+
+mkdir -p "$FAKE_BIN" "$STATUS_DIR" "$PANE_DIR"
+
+cat > "$FAKE_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    display-message)
+        if [ "${2:-}" = "-p" ] && [ "${3:-}" = "#{session_name}" ]; then
+            echo "bg-task"
+            exit 0
+        fi
+        ;;
+esac
+
+exit 1
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+
+    if [ "$expected" != "$actual" ]; then
+        echo "Assertion failed: $message" >&2
+        echo "Expected: $expected" >&2
+        echo "Actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+# Pipe a Stop payload (arbitrary JSON) through the hook for a given pane.
+run_stop() {
+    local pane_id="$1"
+    local payload="$2"
+
+    printf '%s\n' "$payload" | \
+        PATH="$FAKE_BIN:$PATH" \
+        HOME="$TEST_HOME" \
+        TMUX="/tmp/tmux-test,4242,0" \
+        TMUX_PANE="$pane_id" \
+        "$REPO_DIR/hooks/better-hook.sh" "Stop"
+}
+
+RUNNING_PAYLOAD='{"hook_event_name":"Stop","background_tasks":[{"id":"btr8gibw5","type":"shell","status":"running","description":"Sleep for 25 seconds","command":"sleep 25"}],"session_crons":[]}'
+EMPTY_PAYLOAD='{"hook_event_name":"Stop","background_tasks":[],"session_crons":[]}'
+LEGACY_PAYLOAD='{"hook_event_name":"Stop"}'
+
+# A Stop fired while a background task is still running must keep the agent
+# working rather than flipping to done.
+run_stop "%1" "$RUNNING_PAYLOAD"
+assert_eq "working" "$(cat "$STATUS_DIR/bg-task.status")" "Stop with a running background task keeps the session working"
+assert_eq "working" "$(cat "$PANE_DIR/bg-task_%1.status")" "Stop with a running background task keeps the pane working"
+
+# When the task finishes Claude fires another Stop with an empty array — done.
+run_stop "%1" "$EMPTY_PAYLOAD"
+assert_eq "done" "$(cat "$STATUS_DIR/bg-task.status")" "Stop with no running background tasks marks the session done"
+assert_eq "done" "$(cat "$PANE_DIR/bg-task_%1.status")" "Stop with no running background tasks marks the pane done"
+
+# Older Claude versions omit background_tasks entirely — must behave as before.
+run_stop "%1" "$LEGACY_PAYLOAD"
+assert_eq "done" "$(cat "$STATUS_DIR/bg-task.status")" "Stop without a background_tasks field degrades to done"
+
+echo "Claude background-task hook regression checks passed"


### PR DESCRIPTION
The badge flips to a green checkmark while a backgrounded command is still running.

## Problem

The `Stop` hook unconditionally writes `done`. But `Stop` fires when the agent **yields its turn**, not when work finishes. A Bash command run with `run_in_background: true` (or `ctrl-b ctrl-b`) returns immediately, the agent ends its turn, `Stop` fires → the session shows **done/green** while the command keeps running for minutes.

A foreground blocking tool keeps the turn open, so that case is already correct — this only affects backgrounded work.

## Fix (hook-only, no polling)

The `Stop` payload already carries the answer — a `background_tasks` array with each task’s `status`. The hook was discarding stdin (`cat >/dev/null`); it now reads the payload and stays `working` when any background task is still `running`. When the task finishes, Claude re-invokes the agent and fires another `Stop` with an empty array, which flips the session to `done`. No daemon, no process-tree inspection, no pane scraping — consistent with the project’s hook-driven design.

Detection uses `jq` when present, with a dependency-free shell fallback. Older Claude versions that omit the field degrade to the previous `done` behaviour.

## Evidence

Captured from real Claude Code `Stop` payloads (v2.1.150) by logging hook stdin while a `run_in_background` Bash task was live:

```jsonc
// Stop #1 — agent yielded, task still running  → now stays "working"
"background_tasks":[{"id":"btr8gibw5","type":"shell","status":"running",
                     "description":"Sleep for 25 seconds","command":"sleep 25"}]

// Stop #2 — fired automatically when the task finished → "done"
"background_tasks":[]
```

Verified end-to-end in a live tmux session (before/after): unpatched flips to `done` ~4s in while the task runs for 37s; patched holds `working` until the task completes.

## Scope

This covers **Claude-managed** background tasks — started with `run_in_background` (or `ctrl-b ctrl-b`), which Claude tracks in the `Stop` payload’s `background_tasks` array. It intentionally does **not** cover OS-detached processes (`nohup`/`setsid`/`disown`/`&` that reparent to PID 1): Claude treats the launching tool as finished the instant it returns, so `background_tasks` is empty and the agent genuinely is idle. Surfacing those would require process polling, which this plugin deliberately avoids.

## Tests

- Adds `tests/claude-hook-background-task.sh`: running → `working`, empty array → `done`, and a legacy payload with no field → `done`.
- Full existing suite passes; both the `jq` and no-`jq` fallback paths verified.