### PR TITLE
Close sessions/windows without confirmation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ Inside the popup switcher:
 - `Enter` switches to the selected session, window, or pane
 - `Tab` expands or collapses the selected session or window
 - `Ctrl-X` closes the selected pane immediately
-- `Ctrl-X` on a window closes that window and all child panes after confirmation
-- `Ctrl-X` on a session closes that session and all child windows and panes after confirmation
+- `Ctrl-X` on a window immediately closes that window and all child panes
+- `Ctrl-X` on a session immediately closes that session and all child windows and panes
 - `Ctrl-P` parks or unparks the selected session, window, or pane
 - `Ctrl-W` opens wait mode for the selected target, or cancels an existing wait
 - `Ctrl-R` resets tracked state

--- a/scripts/lib/selection-targets.sh
+++ b/scripts/lib/selection-targets.sh
@@ -95,9 +95,10 @@ selection_tmux_target() {
 }
 
 selection_requires_confirmation() {
-    local scope
-    scope=$(selection_scope "$1" "$2") || return 1
-    [ "$scope" != "pane" ]
+    # Customized: close sessions/windows/panes immediately without a
+    # confirmation prompt. Original behavior asked to confirm for any
+    # non-pane scope: [ "$scope" != "pane" ].
+    return 1
 }
 
 selection_label() {

--- a/tests/switcher-close-actions.sh
+++ b/tests/switcher-close-actions.sh
@@ -9,11 +9,18 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 STATE_DIR="$TMP_DIR/state"
 mkdir -p "$STATE_DIR"
 
+session_actions="$("$REPO_DIR/scripts/hook-based-switcher.sh" --state-dir "$STATE_DIR" --close-fzf-actions "repo" "S")"
 window_actions="$("$REPO_DIR/scripts/hook-based-switcher.sh" --state-dir "$STATE_DIR" --close-fzf-actions "repo:w0" "P")"
 pane_actions="$("$REPO_DIR/scripts/hook-based-switcher.sh" --state-dir "$STATE_DIR" --close-fzf-actions "repo:%1" "P")"
 
-if [[ "$window_actions" != *"--popup-close repo:w0 P"* ]] || [[ "$window_actions" != *"+abort"* ]]; then
-    echo "Assertion failed: window close actions should abort fzf and route through popup-close" >&2
+if [[ "$session_actions" != *"--close repo S"* ]] || [[ "$session_actions" != *"+reload("* ]]; then
+    echo "Assertion failed: session close actions should close directly and reload the list" >&2
+    echo "$session_actions" >&2
+    exit 1
+fi
+
+if [[ "$window_actions" != *"--close repo:w0 P"* ]] || [[ "$window_actions" != *"+reload("* ]]; then
+    echo "Assertion failed: window close actions should close directly and reload the list" >&2
     echo "$window_actions" >&2
     exit 1
 fi

--- a/tests/switcher-close-confirmation.sh
+++ b/tests/switcher-close-confirmation.sh
@@ -24,8 +24,11 @@ case "\${1:-}" in
         fi
         exit 1
         ;;
-    confirm-before)
+    run-shell)
         exit 0
+        ;;
+    confirm-before)
+        exit 1
         ;;
     *)
         exit 1
@@ -38,10 +41,16 @@ PATH="$FAKE_BIN:$PATH" \
 HOME="$TMP_DIR/home" \
 "$REPO_DIR/scripts/hook-based-switcher.sh" --close "repo:w0" "P"
 
-if ! grep -Fq "confirm-before -p Close window repo:0 (build) and all child panes?" "$LOG_FILE"; then
-    echo "Assertion failed: switcher window close should request confirmation" >&2
+if grep -Fq "confirm-before" "$LOG_FILE"; then
+    echo "Assertion failed: switcher window close should not request confirmation" >&2
     cat "$LOG_FILE" >&2
     exit 1
 fi
 
-echo "switcher close confirmation regression checks passed"
+if ! grep -Fq "run-shell -b $REPO_DIR/scripts/close-target.sh repo:w0 P" "$LOG_FILE"; then
+    echo "Assertion failed: switcher window close should dispatch close-target directly" >&2
+    cat "$LOG_FILE" >&2
+    exit 1
+fi
+
+echo "switcher close without confirmation regression checks passed"

--- a/tests/switcher-popup-close-confirmation.sh
+++ b/tests/switcher-popup-close-confirmation.sh
@@ -24,8 +24,11 @@ case "\${1:-}" in
         fi
         exit 1
         ;;
-    confirm-before)
+    run-shell)
         exit 0
+        ;;
+    confirm-before)
+        exit 1
         ;;
     *)
         exit 1
@@ -38,10 +41,16 @@ PATH="$FAKE_BIN:$PATH" \
 HOME="$TMP_DIR/home" \
 "$REPO_DIR/scripts/hook-based-switcher.sh" --popup-close "repo:w0" "P"
 
-if ! grep -Fq "confirm-before -b -p Close window repo:0 (build) and all child panes?" "$LOG_FILE"; then
-    echo "Assertion failed: popup close should request background confirmation for window targets" >&2
+if grep -Fq "confirm-before" "$LOG_FILE"; then
+    echo "Assertion failed: popup close should not request confirmation for window targets" >&2
     cat "$LOG_FILE" >&2
     exit 1
 fi
 
-echo "switcher popup close confirmation regression checks passed"
+if ! grep -Fq "run-shell -b $REPO_DIR/scripts/close-target.sh repo:w0 P" "$LOG_FILE"; then
+    echo "Assertion failed: popup close should dispatch close-target directly" >&2
+    cat "$LOG_FILE" >&2
+    exit 1
+fi
+
+echo "switcher popup close without confirmation regression checks passed"


### PR DESCRIPTION
## What

`Ctrl-X` in the sidebar/switcher currently asks for confirmation before closing a session or window (panes already close immediately). This makes `selection_requires_confirmation()` always return false so sessions, windows, and panes all close without a prompt.

## Why

The confirmation step adds friction to the most common close action. This removes it so `Ctrl-X` closes the selected target straight away.

## Change

Single function in `scripts/lib/selection-targets.sh`:

```sh
selection_requires_confirmation() {
    return 1
}
```

All close paths (`sidebar.sh`, `hook-based-switcher.sh`, `close-target.sh`) gate on this function, so the two `confirm-before` call sites in the switcher become unreachable and closing happens directly via `dispatch_close_job` / `close-target.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)