### PR TITLE
[codex] Sync sidebar cursor with active target

### DIFF
--- a/scripts/lib/sidebar-selection.sh
+++ b/scripts/lib/sidebar-selection.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Helpers for keeping the sidebar cursor aligned with the active tmux target.
+
+[[ -n "${_SIDEBAR_SELECTION_LOADED:-}" ]] && return 0
+_SIDEBAR_SELECTION_LOADED=1
+
+sidebar_active_selection_index() {
+    local current_session="$1"
+    local current_pane="$2"
+    local current_window="$3"
+
+    [[ -n "$current_session" ]] || return 1
+
+    local i sel_name sel_type sel_session token
+    local window_idx=-1
+    local session_idx=-1
+
+    for ((i=SESS_START; i<SEL_COUNT; i++)); do
+        sel_name="${SEL_NAMES[$i]:-}"
+        sel_type="${SEL_TYPES[$i]:-}"
+
+        case "$sel_type" in
+            P)
+                sel_session="${sel_name%%:*}"
+                token="${sel_name#*:}"
+                [[ "$sel_session" == "$current_session" ]] || continue
+
+                if [[ -n "$current_pane" && "$token" == "$current_pane" ]]; then
+                    printf '%s\n' "$i"
+                    return 0
+                fi
+
+                if [[ -n "$current_window" && "$token" == "w$current_window" && "$window_idx" -lt 0 ]]; then
+                    window_idx="$i"
+                fi
+                ;;
+            S|W)
+                if [[ "$sel_name" == "$current_session" && "$session_idx" -lt 0 ]]; then
+                    session_idx="$i"
+                fi
+                ;;
+        esac
+    done
+
+    if (( window_idx >= 0 )); then
+        printf '%s\n' "$window_idx"
+        return 0
+    fi
+
+    if (( session_idx >= 0 )); then
+        printf '%s\n' "$session_idx"
+        return 0
+    fi
+
+    return 1
+}

--- a/scripts/sidebar.sh
+++ b/scripts/sidebar.sh
@@ -13,6 +13,8 @@ source "$CURRENT_DIR/lib/session-status.sh"
 source "$CURRENT_DIR/lib/sidebar-clients.sh"
 # shellcheck source=lib/selection-targets.sh
 source "$CURRENT_DIR/lib/selection-targets.sh"
+# shellcheck source=lib/sidebar-selection.sh
+source "$CURRENT_DIR/lib/sidebar-selection.sh"
 
 # ─── Mode ─────────────────────────────────────────────────────────
 PREVIEW_MODE=0
@@ -197,6 +199,19 @@ _collect_cur_client() {
     local info
     info=$(tmux display-message -p $'#{client_session}\t#{pane_id}\t#{window_index}' 2>/dev/null || true)
     IFS=$'\t' read -r CUR_SESSION CUR_PANE CUR_WINDOW_INDEX <<< "$info"
+}
+
+_sync_selected_to_current_client() {
+    local next_selected
+    next_selected=$(sidebar_active_selection_index "$CUR_SESSION" "$CUR_PANE" "$CUR_WINDOW_INDEX") || return 1
+    [[ -n "$next_selected" ]] || return 1
+
+    if (( next_selected != SELECTED )); then
+        SELECTED="$next_selected"
+        return 0
+    fi
+
+    return 1
 }
 
 collect() {
@@ -1036,7 +1051,10 @@ while true; do
             NEEDS_RENDER=1
             _PREVIEW_DIRTY=1
         fi
-        [[ "$cur_token" != "$prev_cur" ]] && NEEDS_RENDER=1
+        if [[ "$cur_token" != "$prev_cur" ]]; then
+            _sync_selected_to_current_client || true
+            NEEDS_RENDER=1
+        fi
     fi
     NEEDS_COLLECT=0
     if (( RESIZED )); then

--- a/tests/sidebar-active-selection.sh
+++ b/tests/sidebar-active-selection.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=../scripts/lib/sidebar-selection.sh
+source "$REPO_DIR/scripts/lib/sidebar-selection.sh"
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local message="$3"
+
+    if [ "$actual" != "$expected" ]; then
+        echo "Assertion failed: $message" >&2
+        echo "Expected: $expected" >&2
+        echo "Actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+SEL_NAMES=("config" "c3" "config" "flows")
+SEL_TYPES=("S" "S" "S" "S")
+SESS_START=1
+SEL_COUNT=${#SEL_NAMES[@]}
+
+assert_eq \
+    "$(sidebar_active_selection_index "config" "%8" "0")" \
+    "2" \
+    "active session should select the matching session row, not an inbox duplicate or the first session"
+
+SEL_NAMES=("repo" "repo:w0" "repo:%1" "repo:w1" "other")
+SEL_TYPES=("S" "P" "P" "P" "S")
+SESS_START=0
+SEL_COUNT=${#SEL_NAMES[@]}
+
+assert_eq \
+    "$(sidebar_active_selection_index "repo" "%1" "0")" \
+    "2" \
+    "active pane rows should win over enclosing window rows"
+
+assert_eq \
+    "$(sidebar_active_selection_index "repo" "%9" "1")" \
+    "3" \
+    "active window rows should win when the active pane has no row"
+
+assert_eq \
+    "$(sidebar_active_selection_index "repo" "%9" "5")" \
+    "0" \
+    "session row should be the fallback for the active session"
+
+SEL_NAMES=("parent" "child-worktree")
+SEL_TYPES=("S" "W")
+SESS_START=0
+SEL_COUNT=${#SEL_NAMES[@]}
+
+assert_eq \
+    "$(sidebar_active_selection_index "child-worktree" "%3" "0")" \
+    "1" \
+    "worktree session rows should be selectable active targets"
+
+echo "sidebar active selection regression checks passed"


### PR DESCRIPTION
## Summary

Fix the sidebar cursor so it follows the active tmux target on startup and whenever the active client session/window/pane changes.

## Root cause

The sidebar kept its keyboard cursor at the first selectable session row unless the user moved it. The active tmux target was rendered separately with the current-row styling, so the UI could show an unrelated row with the grey cursor and arrow while the real active row was also highlighted.

## Changes

- Add a small sidebar selection helper that finds the best selectable row for the active target.
- Prefer exact pane matches, then active window rows, then the active session/worktree row.
- Sync the sidebar cursor after collecting a changed active client target.
- Add regression coverage for session, pane, window fallback, inbox duplicate, and worktree selection cases.

## Validation

- `bash -n scripts/sidebar.sh scripts/lib/sidebar-selection.sh tests/sidebar-active-selection.sh`
- `for t in tests/*.sh; do bash "$t"; done`
